### PR TITLE
add 2D led spectrum analyser - (remix)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,7 +57,8 @@ struct Preset {
 
 #if defined(HAS_GLES)
 const std::vector<Preset> g_presets =
-  {{"Input Sound by iq",                        "input.frag.glsl",                  -1, -1},
+  {{"2D LED Spectrum by uNiversal",             "2Dspectrum.frag.glsl",             -1, -1},
+   {"Input Sound by iq",                        "input.frag.glsl",                  -1, -1},
    {"LED spectrum by simesgreen",               "ledspectrum.frag.glsl",            -1, -1},
    {"Audio Reaktive by choard1895",             "audioreaktive.frag.glsl",          -1, -1},
    {"AudioVisual by Passion",                   "audiovisual.frag.glsl",            -1, -1},
@@ -75,7 +76,8 @@ const std::vector<Preset> g_presets =
    {"Waves Remix by ADOB",                      "wavesremix.frag.glsl",             -1, -1}};
 #else
 const std::vector<Preset> g_presets =
-  {{"Audio Reaktive by choard1895",             "audioreaktive.frag.glsl",          -1, -1},
+  {{"2D LED Spectrum by uNiversal",             "2Dspectrum.frag.glsl",             -1, -1},
+   {"Audio Reaktive by choard1895",             "audioreaktive.frag.glsl",          -1, -1},
    {"AudioVisual by Passion",                   "audiovisual.frag.glsl",            -1, -1},
    {"Beating Circles by Phoenix72",             "beatingcircles.frag.glsl",         -1, -1},
    {"BPM by iq",                                "bpm.frag.glsl",                    -1, -1},

--- a/visualization.shadertoy/resources/2Dspectrum.frag.glsl
+++ b/visualization.shadertoy/resources/2Dspectrum.frag.glsl
@@ -1,0 +1,37 @@
+/*
+2D LED Spectrum - Visualiser - https://www.shadertoy.com/view/Mlj3WV#
+Based on Led Spectrum Analiser by: simesgreen - 27th February, 2013 - https://www.shadertoy.com/view/Msl3zr
+2D LED Spectrum by: uNiversal - 27th May, 2015
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+*/
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord )
+{
+    // create pixel coordinates
+    vec2 uv = fragCoord.xy / iResolution.xy;
+
+    // quantize coordinates
+    const float bands = 30.0;
+    const float segs = 40.0;
+    vec2 p;
+    p.x = floor(uv.x*bands)/bands;
+    p.y = floor(uv.y*segs)/segs;
+
+    // read frequency data from first row of texture
+    float fft  = texture2D( iChannel0, vec2(p.x,0.0) ).x;
+
+    // led color
+    vec3 color = mix(vec3(0.0, 2.0, 0.0), vec3(2.0, 0.0, 0.0), sqrt(uv.y));
+
+    // mask for bar graph
+    float mask = (p.y < fft) ? 1.0 : 0.1;
+
+    // led shape
+    vec2 d = fract((uv - p)*vec2(bands, segs)) - 0.5;
+    float led = smoothstep(0.5, 0.35, abs(d.x)) *
+                smoothstep(0.5, 0.35, abs(d.y));
+    vec3 ledColor = led*color*mask;
+
+    // output final color
+    fragColor = vec4(ledColor, 1.0);
+}


### PR DESCRIPTION
Best reviewed with **?w=1** https://github.com/uNiversaI/visualization.shadertoy/commit/82c66029720f76385d1e6c46f82b17f7d6a27dcd?w=1

See http://forum.kodi.tv/showthread.php?tid=204991&pid=2011733#pid2011733

Can be seen in action at https://www.shadertoy.com/view/Mlj3WV#

I tried to match it as closely to the request in forums http://forum.kodi.tv/showthread.php?tid=204991&pid=1799716#pid1799716

This is as close as I could get hacking around with this, maybe @topfs2 or somone can give me a few pointers and see if I can indeed get it to exact match (i.e the trailing grey peak indicators) which would make this extra nice.

It works a treat in Kodi (My wife and other women in family all agreed)

Some screenshots for an idea.

![screenshot015](https://cloud.githubusercontent.com/assets/3521959/7802552/3be28a1a-0330-11e5-9d42-c9c8f994d0c1.png)
![screenshot017](https://cloud.githubusercontent.com/assets/3521959/7802553/3be48a2c-0330-11e5-892f-32c440003e24.png)
![screenshot018](https://cloud.githubusercontent.com/assets/3521959/7802555/3be58fc6-0330-11e5-9e70-d05e2110537f.png)
![screenshot019](https://cloud.githubusercontent.com/assets/3521959/7802556/3be6407e-0330-11e5-8155-d23fdbc68a5b.png)
