### PR TITLE
[shaders] cleanup tabs vs spaces + indenting and whitelines

### DIFF
--- a/visualization.shadertoy/resources/audioreaktive.frag.glsl
+++ b/visualization.shadertoy/resources/audioreaktive.frag.glsl
@@ -13,155 +13,149 @@
 //If you comment gamma but leave contrast you'll get a solarized effect.
 //#define POST_PROC
 
-
 #define BEAT_POINT 0.3
-
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	//screenspace mapping
-	vec2 uv = fragCoord.xy / iResolution.xy;
-	
-	vec3 final_color, bg_color, wave_color;
-	
-	//establish a reasonable beat estimation
-	float beat = texture2D(iChannel0, vec2(BEAT_POINT, 0.0)).x;
-	beat = beat * beat;
-	
-	//sun.x is desaturation. (-1.0 - 1.0) is good
-	//sun.y is hue-related (keep around 0.2 - 1.0)
-	//sun.z is contrast-related (keep around 0.7 - 1.0)
-	//base values are -0.64, 0.96, 0.99
-	vec3 sun = vec3(-0.64, 0.96, 0.99);
-	
-	//forget static shading. let's get dynamic!
-	sun.x = -0.8 + beat*1.5;
-	sun.y = 0.7 + 0.3 * cos(uv.x*6.0+20.0*(uv.y-0.5)*(beat-0.2) + iGlobalTime);
-	sun.z = 0.9 + 0.1 * cos(iGlobalTime);
-	
-	//crazy intense dubstep-ize the colors
-	#ifdef ALT_MODE
-		sun.x = -cos(iGlobalTime);
-		sun.y = 0.7 + 0.3 * cos(uv.x*6.0+20.0*(uv.y-0.5)*(beat-0.2) + iGlobalTime);
-		sun.z = 0.85 + 0.35 * cos(iGlobalTime);
-	#endif
-	
-	sun.xy = 0.5 + 0.5 * sun.xy;
-	sun = normalize(sun);
-	
-	//waveform at x-coord
-	float hwf = texture2D(iChannel0, vec2(uv.x,1.0)).x;
-	float vwf = texture2D(iChannel0, vec2(uv.y,1.0)).x;
-	
-	#ifdef ALT_MODE
-	float noise = texture2D(iChannel0, vec2(vwf,1.0)).x;
-	float distort = (vwf - 0.5) * beat * beat * beat;
-	
-	//distort and wrap, triangle mod
-	uv.x = abs(uv.x + distort);
-	if (uv.x > 1.0) uv.x = 2.0 - uv.x;
-	#endif
-	
-	
-	//four distortion patterns
-	float coord1 = sin(uv.x + hwf) - cos(uv.y);
-	float coord2 = sin(1.0 - uv.x + hwf) - sin(uv.y * 3.0);
-	//float coord3 = cos(uv.x+sin(0.2*iGlobalTime)) - sin(2.5*uv.y - wf);
-	float coord4 = mix(coord1, coord2,hwf);
-	float coord5 = mix(coord1, coord2, beat);
-	
-	float coorda = mix(coord1, coord2, 0.5 + 0.5 *sin(iGlobalTime*0.7));
-	float coordb = mix(coord5, coord4, 0.5 + 0.5 *sin(iGlobalTime*0.5));
-	
-	//mix distortions based on time
-	float coord = mix(coorda, coordb, 0.5 + 0.5 *sin(iGlobalTime*0.3));
+    //screenspace mapping
+    vec2 uv = fragCoord.xy / iResolution.xy;
 
-	//distort the spectrum image using the above coords
-	float j = (texture2D(iChannel0, vec2(abs(coord),0.0)).x - 0.5) * 2.0;
+    vec3 final_color, bg_color, wave_color;
 
-	//greyscale -> color with a lot of dot products
-	float fac1 = dot(vec3(uv.x,uv.y,j),sun);
-	float fac2 = dot(vec3(uv.y,j,uv.x),sun);
-	float fac3 = dot(vec3(j,uv.x,uv.y),sun);
-	bg_color = vec3(fac1,fac2,fac3);
+    //establish a reasonable beat estimation
+    float beat = texture2D(iChannel0, vec2(BEAT_POINT, 0.0)).x;
+    beat = beat * beat;
 
-	
-	//extract some info about wave shape
-	float w1 = texture2D(iChannel0, vec2(0.1,0.0)).x;
-	float w2 = texture2D(iChannel0, vec2(0.2,0.0)).x;
-	float w3 = texture2D(iChannel0, vec2(0.4,0.0)).x;
-	float w4 = texture2D(iChannel0, vec2(0.8,0.0)).x;
-	
-	//save screenspace for later
-	vec2 ouv = uv;
-	
-	
-	float wave_width = 0.0;
-	float wave_amp = 0.0;
-	
-	//rescale to aspect-aware [-1, 1]
-	uv  = -1.0 + 2.0 * uv;
-	uv.y *= iResolution.y/iResolution.x;
-	
-	#ifdef ALT_MODE
-	//bend-spin-stretch the coord system based on wave shape
-	float theta = (w1 - w2 + w3 - w4) * 3.14;
-	uv = uv*mat2(cos(theta * 0.2),-sin(theta * 0.3),sin(theta * 0.5),cos(theta * 0.7));
-	#endif
-	
-	//for polar calculations
-	float rad = length(uv) - 0.3;
-	
-	float h;
-	
-	//slightly based on Waves by bonniem 
-	for(float i = 0.0; i < 10.0; i++) {
-		//build a simple trig series based on wave shape
-		//note that waves are in rectangular coords
-		h = sin(uv.x*8.0+iGlobalTime)*0.2*w1+ 
-			sin(uv.x*16.0-2.0*iGlobalTime)*0.2*w2 + 
-			sin(uv.x*32.0+3.0*iGlobalTime)*0.2*w3 + 
-			sin(uv.x*64.0-4.0*iGlobalTime)*0.2*w4;
-		rad += h * 0.4;
-		//find the wave section's width in polar coords
-		wave_width = abs(1.0 / (100.0 * rad));
-		wave_amp += wave_width;
-	}
-	
-	//color waves based on sonar shape and screen position
-	wave_color = vec3(0.2 + w2*1.5, 0.1 + w4*2.0 + uv.y*0.1, 0.1 + w3*2.0+uv.x*0.1);
-	
-	#ifdef ALT_MODE
-	//fade with beat
-	wave_amp *= beat * 3.0;
-	#endif
-	
-	//modulate with waveform. doesn't do much.
-	wave_amp *= hwf*2.0;
-	
-	
-	//fade bg in from 0 to 5 sec
-	final_color = bg_color*smoothstep(0.0,5.0,iChannelTime[0]);
-	final_color += 0.12*wave_color*wave_amp;
-	
-	//postproc code from iq :)
-	#ifdef POST_PROC
-	 //gamma. remove this for a solarized look	
-	final_color = pow( clamp( final_color, 0.0, 1.0 ), vec3(1.7) );
+    //sun.x is desaturation. (-1.0 - 1.0) is good
+    //sun.y is hue-related (keep around 0.2 - 1.0)
+    //sun.z is contrast-related (keep around 0.7 - 1.0)
+    //base values are -0.64, 0.96, 0.99
+    vec3 sun = vec3(-0.64, 0.96, 0.99);
+
+    //forget static shading. let's get dynamic!
+    sun.x = -0.8 + beat*1.5;
+    sun.y = 0.7 + 0.3 * cos(uv.x*6.0+20.0*(uv.y-0.5)*(beat-0.2) + iGlobalTime);
+    sun.z = 0.9 + 0.1 * cos(iGlobalTime);
+
+    //crazy intense dubstep-ize the colors
+    #ifdef ALT_MODE
+        sun.x = -cos(iGlobalTime);
+        sun.y = 0.7 + 0.3 * cos(uv.x*6.0+20.0*(uv.y-0.5)*(beat-0.2) + iGlobalTime);
+        sun.z = 0.85 + 0.35 * cos(iGlobalTime);
+    #endif
+
+    sun.xy = 0.5 + 0.5 * sun.xy;
+    sun = normalize(sun);
+
+    //waveform at x-coord
+    float hwf = texture2D(iChannel0, vec2(uv.x,1.0)).x;
+    float vwf = texture2D(iChannel0, vec2(uv.y,1.0)).x;
+
+    #ifdef ALT_MODE
+    float noise = texture2D(iChannel0, vec2(vwf,1.0)).x;
+    float distort = (vwf - 0.5) * beat * beat * beat;
+
+    //distort and wrap, triangle mod
+    uv.x = abs(uv.x + distort);
+    if (uv.x > 1.0) uv.x = 2.0 - uv.x;
+    #endif
+
+    //four distortion patterns
+    float coord1 = sin(uv.x + hwf) - cos(uv.y);
+    float coord2 = sin(1.0 - uv.x + hwf) - sin(uv.y * 3.0);
+    //float coord3 = cos(uv.x+sin(0.2*iGlobalTime)) - sin(2.5*uv.y - wf);
+    float coord4 = mix(coord1, coord2,hwf);
+    float coord5 = mix(coord1, coord2, beat);
+
+    float coorda = mix(coord1, coord2, 0.5 + 0.5 *sin(iGlobalTime*0.7));
+    float coordb = mix(coord5, coord4, 0.5 + 0.5 *sin(iGlobalTime*0.5));
+
+    //mix distortions based on time
+    float coord = mix(coorda, coordb, 0.5 + 0.5 *sin(iGlobalTime*0.3));
+
+    //distort the spectrum image using the above coords
+    float j = (texture2D(iChannel0, vec2(abs(coord),0.0)).x - 0.5) * 2.0;
+
+    //greyscale -> color with a lot of dot products
+    float fac1 = dot(vec3(uv.x,uv.y,j),sun);
+    float fac2 = dot(vec3(uv.y,j,uv.x),sun);
+    float fac3 = dot(vec3(j,uv.x,uv.y),sun);
+    bg_color = vec3(fac1,fac2,fac3);
+
+    //extract some info about wave shape
+    float w1 = texture2D(iChannel0, vec2(0.1,0.0)).x;
+    float w2 = texture2D(iChannel0, vec2(0.2,0.0)).x;
+    float w3 = texture2D(iChannel0, vec2(0.4,0.0)).x;
+    float w4 = texture2D(iChannel0, vec2(0.8,0.0)).x;
+
+    //save screenspace for later
+    vec2 ouv = uv;
+
+    float wave_width = 0.0;
+    float wave_amp = 0.0;
+
+    //rescale to aspect-aware [-1, 1]
+    uv  = -1.0 + 2.0 * uv;
+    uv.y *= iResolution.y/iResolution.x;
+
+    #ifdef ALT_MODE
+    //bend-spin-stretch the coord system based on wave shape
+    float theta = (w1 - w2 + w3 - w4) * 3.14;
+    uv = uv*mat2(cos(theta * 0.2),-sin(theta * 0.3),sin(theta * 0.5),cos(theta * 0.7));
+    #endif
+
+    //for polar calculations
+    float rad = length(uv) - 0.3;
+
+    float h;
+
+    //slightly based on Waves by bonniem 
+    for(float i = 0.0; i < 10.0; i++) {
+        //build a simple trig series based on wave shape
+        //note that waves are in rectangular coords
+        h = sin(uv.x*8.0+iGlobalTime)*0.2*w1+ 
+            sin(uv.x*16.0-2.0*iGlobalTime)*0.2*w2 + 
+            sin(uv.x*32.0+3.0*iGlobalTime)*0.2*w3 + 
+            sin(uv.x*64.0-4.0*iGlobalTime)*0.2*w4;
+        rad += h * 0.4;
+        //find the wave section's width in polar coords
+        wave_width = abs(1.0 / (100.0 * rad));
+        wave_amp += wave_width;
+    }
+
+    //color waves based on sonar shape and screen position
+    wave_color = vec3(0.2 + w2*1.5, 0.1 + w4*2.0 + uv.y*0.1, 0.1 + w3*2.0+uv.x*0.1);
+
+    #ifdef ALT_MODE
+    //fade with beat
+    wave_amp *= beat * 3.0;
+    #endif
+
+    //modulate with waveform. doesn't do much.
+    wave_amp *= hwf*2.0;
+
+    //fade bg in from 0 to 5 sec
+    final_color = bg_color*smoothstep(0.0,5.0,iChannelTime[0]);
+    final_color += 0.12*wave_color*wave_amp;
+    
+    //postproc code from iq :)
+    #ifdef POST_PROC
+     //gamma. remove this for a solarized look    
+    final_color = pow( clamp( final_color, 0.0, 1.0 ), vec3(1.7) );
 
     //contrast
-	final_color = final_color*0.3 + 0.7*final_color*final_color*(3.0-2.0*final_color);
-	#endif
-	
-	//vignette
-	final_color *= 0.5 + 0.5*pow( 16.0*ouv.x*ouv.y*(1.0-ouv.x)*(1.0-ouv.y), 0.2);
+    final_color = final_color*0.3 + 0.7*final_color*final_color*(3.0-2.0*final_color);
+    #endif
+    
+    //vignette
+    final_color *= 0.5 + 0.5*pow( 16.0*ouv.x*ouv.y*(1.0-ouv.x)*(1.0-ouv.y), 0.2);
 
-	#ifdef ALT_MODE
-//	final_color = mix(final_color, vec3(noise), distort * 10.0);
-	final_color += vec3(noise) * distort * 10.0;
-	#endif
-	
-	fragColor = vec4(final_color, 1.0);
+    #ifdef ALT_MODE
+    //final_color = mix(final_color, vec3(noise), distort * 10.0);
+    final_color += vec3(noise) * distort * 10.0;
+    #endif
+    
+    fragColor = vec4(final_color, 1.0);
 }
 /*
 split into vwf and hwf

--- a/visualization.shadertoy/resources/audiovisual.frag.glsl
+++ b/visualization.shadertoy/resources/audiovisual.frag.glsl
@@ -23,5 +23,3 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
 //2014 - Passion
 //References  - https://www.shadertoy.com/view/Xds3Rr
 //            - tokyodemofest.jp/2014/7lines/index.html
-
-

--- a/visualization.shadertoy/resources/beatingcircles.frag.glsl
+++ b/visualization.shadertoy/resources/beatingcircles.frag.glsl
@@ -5,31 +5,31 @@ float beat = 0.;
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	float ct = iChannelTime[0];
-	if ((ct > 8.0 && ct < 33.5)
-	|| (ct > 38.0 && ct < 88.5)
-	|| (ct > 93.0 && ct < 194.5))
-		beat = pow(sin(ct*3.1416*3.78+1.9)*0.5+0.5,15.0)*0.1;
+    float ct = iChannelTime[0];
+    if ((ct > 8.0 && ct < 33.5)
+    || (ct > 38.0 && ct < 88.5)
+    || (ct > 93.0 && ct < 194.5))
+        beat = pow(sin(ct*3.1416*3.78+1.9)*0.5+0.5,15.0)*0.1;
 
-	float scale = iResolution.y / 50.0;
-	float ring = 20.0;
-	float radius = iResolution.x*1.0;
-	float gap = scale*.5;
-	vec2 pos = fragCoord.xy - iResolution.xy*.5;
-	
-	float d = length(pos);
-	
-	// Create the wiggle
-	d += beat*2.0*(sin(pos.y*0.25/scale+iGlobalTime*cos(ct))*sin(pos.x*0.25/scale+iGlobalTime*.5*cos(ct)))*scale*5.0;
-	
-	// Compute the distance to the closest ring
-	float v = mod(d + radius/(ring*2.0), radius/ring);
-	v = abs(v - radius/(ring*2.0));
-	
-	v = clamp(v-gap, 0.0, 1.0);
-	
-	d /= radius;
-	vec3 m = fract((d-1.0)*vec3(ring*-.5, -ring, ring*.25)*0.5);
-	
-	fragColor = vec4(m*v, 1.0);
+    float scale = iResolution.y / 50.0;
+    float ring = 20.0;
+    float radius = iResolution.x*1.0;
+    float gap = scale*.5;
+    vec2 pos = fragCoord.xy - iResolution.xy*.5;
+
+    float d = length(pos);
+
+    // Create the wiggle
+    d += beat*2.0*(sin(pos.y*0.25/scale+iGlobalTime*cos(ct))*sin(pos.x*0.25/scale+iGlobalTime*.5*cos(ct)))*scale*5.0;
+
+    // Compute the distance to the closest ring
+    float v = mod(d + radius/(ring*2.0), radius/ring);
+    v = abs(v - radius/(ring*2.0));
+
+    v = clamp(v-gap, 0.0, 1.0);
+
+    d /= radius;
+    vec3 m = fract((d-1.0)*vec3(ring*-.5, -ring, ring*.25)*0.5);
+
+    fragColor = vec4(m*v, 1.0);
 }

--- a/visualization.shadertoy/resources/bpm.frag.glsl
+++ b/visualization.shadertoy/resources/bpm.frag.glsl
@@ -9,22 +9,21 @@
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	vec2 uv = -1.0+2.0*fragCoord.xy / iResolution.xy;
-    uv.x *= iResolution.x/iResolution.y;		
-	
-	vec3 col = vec3(0.0);
-		
-	float h = fract( 0.25 + 0.5*iChannelTime[0]*BPM/60.0 );
-	float f = 1.0-smoothstep( 0.0, 1.0, h );
-	f *= smoothstep( 4.5, 4.51, iChannelTime[0] );
-	float r = length(uv-0.0) + 0.2*cos(25.0*h)*exp(-4.0*h);
-	f = pow(f,0.5)*(1.0-smoothstep( 0.5, 0.55, r) );
-	float rn = r/0.55;
-	col = mix( col, vec3(0.4+1.5*rn,0.1+rn*rn,0.50)*rn, f );
-	
+    vec2 uv = -1.0+2.0*fragCoord.xy / iResolution.xy;
+    uv.x *= iResolution.x/iResolution.y;        
 
-	col = mix( col, vec3(1.0), smoothstep(  0.0,  3.0, iChannelTime[0] )*exp( -1.00*max(0.0,iChannelTime[0]- 2.5)) );
-	col = mix( col, vec3(1.0), smoothstep( 16.0, 18.0, iChannelTime[0] )*exp( -0.75*max(0.0,iChannelTime[0]-19.0)) );
-	
-	fragColor = vec4(col,1.0);
+    vec3 col = vec3(0.0);
+
+    float h = fract( 0.25 + 0.5*iChannelTime[0]*BPM/60.0 );
+    float f = 1.0-smoothstep( 0.0, 1.0, h );
+    f *= smoothstep( 4.5, 4.51, iChannelTime[0] );
+    float r = length(uv-0.0) + 0.2*cos(25.0*h)*exp(-4.0*h);
+    f = pow(f,0.5)*(1.0-smoothstep( 0.5, 0.55, r) );
+    float rn = r/0.55;
+    col = mix( col, vec3(0.4+1.5*rn,0.1+rn*rn,0.50)*rn, f );
+
+    col = mix( col, vec3(1.0), smoothstep(  0.0,  3.0, iChannelTime[0] )*exp( -1.00*max(0.0,iChannelTime[0]- 2.5)) );
+    col = mix( col, vec3(1.0), smoothstep( 16.0, 18.0, iChannelTime[0] )*exp( -0.75*max(0.0,iChannelTime[0]-19.0)) );
+
+    fragColor = vec4(col,1.0);
 }

--- a/visualization.shadertoy/resources/circlewave.frag.glsl
+++ b/visualization.shadertoy/resources/circlewave.frag.glsl
@@ -4,49 +4,50 @@ const float tau = 6.28318530717958647692;
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	vec2 uv = (fragCoord.xy - iResolution.xy*.5)/iResolution.x;
+    vec2 uv = (fragCoord.xy - iResolution.xy*.5)/iResolution.x;
 
-	uv = vec2(abs(atan(uv.x,uv.y)/(.5*tau)),length(uv));
+    uv = vec2(abs(atan(uv.x,uv.y)/(.5*tau)),length(uv));
 
-	// adjust frequency to look pretty	
-	uv.x *= 1.0/2.0;
-	
-	float seperation = 0.06;
+    // adjust frequency to look pretty    
+    uv.x *= 1.0/2.0;
 
-	vec3 wave = vec3(0.0);
-	const int n = 60;
-	for ( int i=0; i < n; i++ )
-	{
-/*		float u = uv.x*255.0;
-		float f = fract(u);
-		f = f*f*(3.0-2.0*f);
-		u = floor(u);
-		float sound = mix( texture2D( iChannel0, vec2((u+.5)/256.0,.75) ).x, texture2D( iChannel0, vec2((u+1.5)/256.0,.75) ).x, f );*/
-		float sound = texture2D( iChannel0, vec2(uv.x,.75) ).x;
-		
-		// choose colour from spectrum
-		float a = .9*float(i)*tau/float(n)-.6;
-		vec3 phase = smoothstep(-1.0,.5,vec3(cos(a),cos(a-tau/3.0),cos(a-tau*2.0/3.0)));
-		
-		wave += phase*smoothstep(4.0/640.0, 0.0, abs(uv.y - sound*.3));
-		uv.x += seperation/float(n);
-	}
-	wave *= 3.0/float(n);
-		
-	vec3 col = vec3(0);
-	col.z  += texture2D( iChannel0, vec2(.000,.25) ).x;
-	col.zy += texture2D( iChannel0, vec2(.125,.25) ).xx*vec2(1.5,.5);
-	col.zy += texture2D( iChannel0, vec2(.250,.25) ).xx;
-	col.zy += texture2D( iChannel0, vec2(.375,.25) ).xx*vec2(.5,1.5);
-	col.y  += texture2D( iChannel0, vec2(.500,.25) ).x;
-	col.yx += texture2D( iChannel0, vec2(.625,.25) ).xx*vec2(1.5,.5);
-	col.yx += texture2D( iChannel0, vec2(.750,.25) ).xx;
-	col.yx += texture2D( iChannel0, vec2(.875,.25) ).xx*vec2(.5,1.5);
-	col.x  += texture2D( iChannel0, vec2(1.00,.25) ).x;
-	col /= vec3(4.0,7.0,4.0);
-	
-	// vignetting
-	col *= smoothstep( 1.2, 0.0, uv.y );
-	
-	fragColor = vec4(wave+col,1);
+    float separation = 0.06;
+
+    vec3 wave = vec3(0.0);
+    const int n = 60;
+    for ( int i=0; i < n; i++ )
+    {
+/*      float u = uv.x*255.0;
+        float f = fract(u);
+        f = f*f*(3.0-2.0*f);
+        u = floor(u);
+        float sound = mix( texture2D( iChannel0, vec2((u+.5)/256.0,.75) ).x, texture2D( iChannel0, vec2((u+1.5)/256.0,.75) ).x, f );
+*/
+        float sound = texture2D( iChannel0, vec2(uv.x,.75) ).x;
+        
+        // choose colour from spectrum
+        float a = .9*float(i)*tau/float(n)-.6;
+        vec3 phase = smoothstep(-1.0,.5,vec3(cos(a),cos(a-tau/3.0),cos(a-tau*2.0/3.0)));
+        
+        wave += phase*smoothstep(4.0/640.0, 0.0, abs(uv.y - sound*.3));
+        uv.x += separation/float(n);
+    }
+    wave *= 3.0/float(n);
+
+    vec3 col = vec3(0);
+    col.z  += texture2D( iChannel0, vec2(.000,.25) ).x;
+    col.zy += texture2D( iChannel0, vec2(.125,.25) ).xx*vec2(1.5,.5);
+    col.zy += texture2D( iChannel0, vec2(.250,.25) ).xx;
+    col.zy += texture2D( iChannel0, vec2(.375,.25) ).xx*vec2(.5,1.5);
+    col.y  += texture2D( iChannel0, vec2(.500,.25) ).x;
+    col.yx += texture2D( iChannel0, vec2(.625,.25) ).xx*vec2(1.5,.5);
+    col.yx += texture2D( iChannel0, vec2(.750,.25) ).xx;
+    col.yx += texture2D( iChannel0, vec2(.875,.25) ).xx*vec2(.5,1.5);
+    col.x  += texture2D( iChannel0, vec2(1.00,.25) ).x;
+    col /= vec3(4.0,7.0,4.0);
+
+    // vignetting
+    col *= smoothstep( 1.2, 0.0, uv.y );
+
+    fragColor = vec4(wave+col,1);
 }

--- a/visualization.shadertoy/resources/circuits.frag.glsl
+++ b/visualization.shadertoy/resources/circuits.frag.glsl
@@ -1,58 +1,55 @@
 // Taken from https://www.shadertoy.com/view/XlX3Rj#
 
 #define time iGlobalTime*.02
-
-
 #define width .005
-float zoom = .18;
 
+float zoom = .18;
 float shape=0.;
 vec3 color=vec3(0.),randcol;
 
 void formula(vec2 z, float c) {
-	float minit=0.;
-	float o,ot2,ot=ot2=1000.;
-	for (int i=0; i<9; i++) {
-		z=abs(z)/clamp(dot(z,z),.1,.5)-c;
-		float l=length(z);
-		o=min(max(abs(min(z.x,z.y)),-l+.25),abs(l-.25));
-		ot=min(ot,o);
-		ot2=min(l*.1,ot2);
-		minit=max(minit,float(i)*(1.-abs(sign(ot-o))));
-	}
-	minit+=1.;
-	float w=width*minit*2.;
-	float circ=pow(max(0.,w-ot2)/w,6.);
-	shape+=max(pow(max(0.,w-ot)/w,.25),circ);
-	vec3 col=normalize(.1+texture2D(iChannel1,vec2(minit*.1)).rgb);
-	color+=col*(.4+mod(minit/9.-time*10.+ot2*2.,1.)*1.6);
-	color+=vec3(1.,.7,.3)*circ*(10.-minit)*3.*smoothstep(0.,.5,.15+texture2D(iChannel0,vec2(.0,1.)).x-.5);
+    float minit=0.;
+    float o,ot2,ot=ot2=1000.;
+    for (int i=0; i<9; i++) {
+        z=abs(z)/clamp(dot(z,z),.1,.5)-c;
+        float l=length(z);
+        o=min(max(abs(min(z.x,z.y)),-l+.25),abs(l-.25));
+        ot=min(ot,o);
+        ot2=min(l*.1,ot2);
+        minit=max(minit,float(i)*(1.-abs(sign(ot-o))));
+    }
+    minit+=1.;
+    float w=width*minit*2.;
+    float circ=pow(max(0.,w-ot2)/w,6.);
+    shape+=max(pow(max(0.,w-ot)/w,.25),circ);
+    vec3 col=normalize(.1+texture2D(iChannel1,vec2(minit*.1)).rgb);
+    color+=col*(.4+mod(minit/9.-time*10.+ot2*2.,1.)*1.6);
+    color+=vec3(1.,.7,.3)*circ*(10.-minit)*3.*smoothstep(0.,.5,.15+texture2D(iChannel0,vec2(.0,1.)).x-.5);
 }
-
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	vec2 pos = fragCoord.xy / iResolution.xy - .5;
-	pos.x*=iResolution.x/iResolution.y;
-	vec2 uv=pos;
-	float sph = length(uv); sph = sqrt(1. - sph*sph)*1.5; // curve for spheric distortion
-	uv=normalize(vec3(uv,sph)).xy;
-	float a=time+mod(time,1.)*.5;
-	vec2 luv=uv;
-	float b=a*5.48535;
-//	zoom*=1.+sin(time*3.758123)*.8;
-	uv*=mat2(cos(b),sin(b),-sin(b),cos(b));
-	uv+=vec2(sin(a),cos(a*.5))*8.;
-	uv*=zoom;
-	float pix=.5/iResolution.x*zoom/sph;
-	float dof=max(1.,(10.-mod(time,1.)/.01));
-	float c=1.5+mod(floor(time),6.)*.125;
-	for (int aa=0; aa<36; aa++) {
-		vec2 aauv=floor(vec2(float(aa)/6.,mod(float(aa),6.)));
-		formula(uv+aauv*pix*dof,c);
-	}
-	shape/=36.; color/=36.;
-	vec3 colo=mix(vec3(.15),color,shape)*(1.-length(pos))*min(1.,abs(.5-mod(time+.5,1.))*10.);	
-	colo*=vec3(1.2,1.1,1.0);
-	fragColor = vec4(colo,1.0);
+    vec2 pos = fragCoord.xy / iResolution.xy - .5;
+    pos.x*=iResolution.x/iResolution.y;
+    vec2 uv=pos;
+    float sph = length(uv); sph = sqrt(1. - sph*sph)*1.5; // curve for spheric distortion
+    uv=normalize(vec3(uv,sph)).xy;
+    float a=time+mod(time,1.)*.5;
+    vec2 luv=uv;
+    float b=a*5.48535;
+    //zoom*=1.+sin(time*3.758123)*.8;
+    uv*=mat2(cos(b),sin(b),-sin(b),cos(b));
+    uv+=vec2(sin(a),cos(a*.5))*8.;
+    uv*=zoom;
+    float pix=.5/iResolution.x*zoom/sph;
+    float dof=max(1.,(10.-mod(time,1.)/.01));
+    float c=1.5+mod(floor(time),6.)*.125;
+    for (int aa=0; aa<36; aa++) {
+        vec2 aauv=floor(vec2(float(aa)/6.,mod(float(aa),6.)));
+        formula(uv+aauv*pix*dof,c);
+    }
+    shape/=36.; color/=36.;
+    vec3 colo=mix(vec3(.15),color,shape)*(1.-length(pos))*min(1.,abs(.5-mod(time+.5,1.))*10.);    
+    colo*=vec3(1.2,1.1,1.0);
+    fragColor = vec4(colo,1.0);
 }

--- a/visualization.shadertoy/resources/coloredbars.frag.glsl
+++ b/visualization.shadertoy/resources/coloredbars.frag.glsl
@@ -6,110 +6,110 @@
 #define PRECISION     1e-3
 
 float rand(vec2 co){
-	return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
+    return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
 }
 
 float plane(vec3 p, float z) {
-	return p.z - z;
+    return p.z - z;
 }
 
 float udBox(vec3 p, vec3 b, out int object) {
-	float tme = iGlobalTime*2.0 + 1024.0;
+    float tme = iGlobalTime*2.0 + 1024.0;
 
-	p.y += tme / 2.0;
-	float rowOffset = rand(vec2(0, floor(p.y/2.0)));
-	p.x += tme * (2. * rowOffset + texture2D(iChannel0, vec2(rowOffset,.25)).x/500.);
+    p.y += tme / 2.0;
+    float rowOffset = rand(vec2(0, floor(p.y/2.0)));
+    p.x += tme * (2. * rowOffset + texture2D(iChannel0, vec2(rowOffset,.25)).x/500.);
 
-	object = int(6. * mod(p.x/(32.*6.), 1.)) + 2;
+    object = int(6. * mod(p.x/(32.*6.), 1.)) + 2;
 
-	vec2 c = vec2(32, 2);
-	p.xy = mod(p.xy, c)-.5*c;
-	return length(max(abs(p)-b,0.));
+    vec2 c = vec2(32, 2);
+    p.xy = mod(p.xy, c)-.5*c;
+    return length(max(abs(p)-b,0.));
 }
 
 float getMap(vec3 p, out int object) {
-	float distance = MAXDISTANCE;
-	float tempDist;
-	int tempObject;
+    float distance = MAXDISTANCE;
+    float tempDist;
+    int tempObject;
 
-	distance = plane(p, 0.0);
-	object = 1;
+    distance = plane(p, 0.0);
+    object = 1;
 
-	tempDist = udBox(p, vec3(12.0, 0.5, 0.5), tempObject);
-	if (tempDist <= distance) {
-		distance = tempDist;
-		object = tempObject;
-	}
-	return distance * 0.5;
+    tempDist = udBox(p, vec3(12.0, 0.5, 0.5), tempObject);
+    if (tempDist <= distance) {
+        distance = tempDist;
+        object = tempObject;
+    }
+    return distance * 0.5;
 }
 
 vec2 castRay(vec3 origin, vec3 direction, out int object) {
-	float distance = rand(vec2(direction.y * iGlobalTime, direction.x)) * 6.0;
-	float delta = 0.0;
-	object = 0;
+    float distance = rand(vec2(direction.y * iGlobalTime, direction.x)) * 6.0;
+    float delta = 0.0;
+    object = 0;
 
-	for (int i = 0; i < MAXITERATIONS; i++) {
-		vec3 p = origin + direction * distance;
+    for (int i = 0; i < MAXITERATIONS; i++) {
+        vec3 p = origin + direction * distance;
 
-		delta = getMap(p, object);
+        delta = getMap(p, object);
 
-		distance += delta;
-		if (delta < PRECISION) {
-			return vec2(distance, float(i));
-		}
-		if (distance > MAXDISTANCE) {
-			object = 0;
-			return vec2(distance, float(i));
-		}
-	}
-	
-	object = 0;
-	return vec2(distance, MAXITERATIONS);
+        distance += delta;
+        if (delta < PRECISION) {
+            return vec2(distance, float(i));
+        }
+        if (distance > MAXDISTANCE) {
+            object = 0;
+            return vec2(distance, float(i));
+        }
+    }
+
+    object = 0;
+    return vec2(distance, MAXITERATIONS);
 }
 
 vec3 drawScene(vec3 origin, vec3 direction) {
-	vec3 color = vec3(0.0, 0.0, 0.0);
-	int object = 0;
+    vec3 color = vec3(0.0, 0.0, 0.0);
+    int object = 0;
 
-	vec2 ray = castRay(origin, direction, object);
+    vec2 ray = castRay(origin, direction, object);
 
-	if (object != 0) {
-		if (object == 1) {
-			color = vec3(1.0, 1.0, 1.0);
-		}
-		else if (object == 2) {
-			color = vec3(1.0, 0.3, 0.3);
-		}
-		else if (object == 3) {
-			color = vec3(0.3, 1.0, 0.3);
-		}
-		else if (object == 4) {
-			color = vec3(0.3, 0.3, 1.0);
-		}
-		else if (object == 5) {
-			color = vec3(1.0, 1.0, 0.3);
-		}
-		else if (object == 6) {
-			color = vec3(0.3, 1.0, 1.0);
-		}
-		else if (object == 7) {
-			color = vec3(1.0, 0.3, 1.0);
-		}
-	}
-	return mix(color, vec3(0.0, 0.0, 0.0), ray.y/float(MAXITERATIONS));
+    if (object != 0) {
+        if (object == 1) {
+            color = vec3(1.0, 1.0, 1.0);
+        }
+        else if (object == 2) {
+            color = vec3(1.0, 0.3, 0.3);
+        }
+        else if (object == 3) {
+            color = vec3(0.3, 1.0, 0.3);
+        }
+        else if (object == 4) {
+            color = vec3(0.3, 0.3, 1.0);
+        }
+        else if (object == 5) {
+            color = vec3(1.0, 1.0, 0.3);
+        }
+        else if (object == 6) {
+            color = vec3(0.3, 1.0, 1.0);
+        }
+        else if (object == 7) {
+            color = vec3(1.0, 0.3, 1.0);
+        }
+    }
+    return mix(color, vec3(0.0, 0.0, 0.0), ray.y/float(MAXITERATIONS));
 }
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
-	vec2 p = (fragCoord.xy / iResolution.xy) * 2.0 - 1.0;
-	float aspect = iResolution.x / iResolution.y;
-	p.x *= aspect;
-	
-	vec3 color = vec3(0.0, 0.0, 0.0);
-	vec3 origin = vec3(0.0, 0.0, 12.0);
-	vec3 direction = normalize(vec3(p.x, p.y, -1.0));
-	direction.xy = mat2(cos(M_PI/4.0), sin(M_PI/4.0), -sin(M_PI/4.0), cos(M_PI/4.0)) * direction.xy;
-	
-	color = drawScene(origin, direction);
-	
-	fragColor = vec4(color, 1.0);
+    vec2 p = (fragCoord.xy / iResolution.xy) * 2.0 - 1.0;
+    float aspect = iResolution.x / iResolution.y;
+    p.x *= aspect;
+
+    vec3 color = vec3(0.0, 0.0, 0.0);
+    vec3 origin = vec3(0.0, 0.0, 12.0);
+    vec3 direction = normalize(vec3(p.x, p.y, -1.0));
+    direction.xy = mat2(cos(M_PI/4.0), sin(M_PI/4.0), -sin(M_PI/4.0), cos(M_PI/4.0)) * direction.xy;
+
+    color = drawScene(origin, direction);
+
+    fragColor = vec4(color, 1.0);
 }

--- a/visualization.shadertoy/resources/cubescape.frag.glsl
+++ b/visualization.shadertoy/resources/cubescape.frag.glsl
@@ -18,11 +18,11 @@ float dbox( vec3 p, vec3 b, float r )
 
 vec4 texcube( sampler2D sam, in vec3 p, in vec3 n )
 {
-	vec4 x = texture2D( sam, p.yz );
-	vec4 y = texture2D( sam, p.zx );
-	vec4 z = texture2D( sam, p.yx );
+    vec4 x = texture2D( sam, p.yz );
+    vec4 y = texture2D( sam, p.zx );
+    vec4 z = texture2D( sam, p.yx );
     vec3 a = abs(n);
-	return (x*a.x + y*a.y + z*a.z) / (a.x + a.y + a.z);
+    return (x*a.x + y*a.y + z*a.z) / (a.x + a.y + a.z);
 }
 
 //---------------------------------
@@ -31,15 +31,15 @@ float freqs[4];
 
 vec3 mapH( in vec2 pos )
 {
-	vec2 fpos = fract( pos ); 
-	vec2 ipos = floor( pos );
-	
-    float f = 0.0;	
-	float id = hash( ipos.x + ipos.y*57.0 );
-	f += freqs[0] * clamp(1.0 - abs(id-0.20)/0.30, 0.0, 1.0 );
-	f += freqs[1] * clamp(1.0 - abs(id-0.40)/0.30, 0.0, 1.0 );
-	f += freqs[2] * clamp(1.0 - abs(id-0.60)/0.30, 0.0, 1.0 );
-	f += freqs[3] * clamp(1.0 - abs(id-0.80)/0.30, 0.0, 1.0 );
+    vec2 fpos = fract( pos ); 
+    vec2 ipos = floor( pos );
+
+    float f = 0.0;    
+    float id = hash( ipos.x + ipos.y*57.0 );
+    f += freqs[0] * clamp(1.0 - abs(id-0.20)/0.30, 0.0, 1.0 );
+    f += freqs[1] * clamp(1.0 - abs(id-0.40)/0.30, 0.0, 1.0 );
+    f += freqs[2] * clamp(1.0 - abs(id-0.60)/0.30, 0.0, 1.0 );
+    f += freqs[3] * clamp(1.0 - abs(id-0.80)/0.30, 0.0, 1.0 );
 
     f = pow( clamp( f, 0.0, 1.0 ), 2.0 );
     float h = 2.5*f;
@@ -49,9 +49,9 @@ vec3 mapH( in vec2 pos )
 
 vec3 map( in vec3 pos )
 {
-	vec2  p = fract( pos.xz ); 
+    vec2  p = fract( pos.xz ); 
     vec3  m = mapH( pos.xz );
-	float d = dbox( vec3(p.x-0.5,pos.y-0.5*m.x,p.y-0.5), vec3(0.3,m.x*0.5,0.3), 0.1 );
+    float d = dbox( vec3(p.x-0.5,pos.y-0.5*m.x,p.y-0.5), vec3(0.3,m.x*0.5,0.3), 0.1 );
     return vec3( d, m.yz );
 }
 
@@ -64,15 +64,15 @@ vec3 trace( in vec3 ro, in vec3 rd, in float startf, in float maxd )
     float t = startf;
 
     float sid = -1.0;
-	float alt = 0.0;
+    float alt = 0.0;
     for( int i=0; i<128; i++ )
     {
         if( s<surface || t>maxd ) break;
         t += 0.15*s;
-	    vec3 res = map( ro + rd*t );
+        vec3 res = map( ro + rd*t );
         s   = res.x;
-	    sid = res.y;
-		alt = res.z;
+        sid = res.y;
+        alt = res.z;
     }
     if( t>maxd ) sid = -1.0;
     return vec3( t, sid, alt );
@@ -83,34 +83,33 @@ vec3 trace( in vec3 ro, in vec3 rd, in float startf, in float maxd )
 vec3 trace( vec3 ro, in vec3 rd, in float tmin, in float tmax )
 {
     ro += tmin*rd;
-    
-	vec2 pos = floor(ro.xz);
+
+    vec2 pos = floor(ro.xz);
     vec3 rdi = 1.0/rd;
     vec3 rda = abs(rdi);
-	vec2 rds = sign(rd.xz);
-	vec2 dis = (pos-ro.xz+ 0.5 + rds*0.5) * rdi.xz;
-	
-	vec3 res = vec3( -1.0 );
+    vec2 rds = sign(rd.xz);
+    vec2 dis = (pos-ro.xz+ 0.5 + rds*0.5) * rdi.xz;
+
+    vec3 res = vec3( -1.0 );
 
     // traverse regular grid (in 2D)
-	vec2 mm = vec2(0.0);
-	for( int i=0; i<28; i++ ) 
-	{
+    vec2 mm = vec2(0.0);
+    for( int i=0; i<28; i++ ) 
+    {
         vec3 cub = mapH( pos );
 
         #if 1
             vec2 pr = pos+0.5-ro.xz;
-			vec2 mini = (pr-0.5*rds)*rdi.xz;
-	        float s = max( mini.x, mini.y );
+            vec2 mini = (pr-0.5*rds)*rdi.xz;
+            float s = max( mini.x, mini.y );
             if( (tmin+s)>tmax ) break;
         #endif
-        
-        
+
         // intersect box
-		vec3  ce = vec3( pos.x+0.5, 0.5*cub.x, pos.y+0.5 );
+        vec3  ce = vec3( pos.x+0.5, 0.5*cub.x, pos.y+0.5 );
         vec3  rb = vec3(0.3,cub.x*0.5,0.3);
         vec3  ra = rb + 0.12;
-		vec3  rc = ro - ce;
+        vec3  rc = ro - ce;
         float tN = maxcomp( -rdi*rc - rda*ra );
         float tF = maxcomp( -rdi*rc + rda*ra );
         if( tN < tF )//&& tF > 0.0 )
@@ -130,22 +129,19 @@ vec3 trace( vec3 ro, in vec3 rd, in float tmin, in float tmax )
                 res = vec3( s, cub.yz );
                 break; 
             }
-            
-		}
+        }
 
-        
-        // step to next cell		
-		mm = step( dis.xy, dis.yx ); 
-		dis += mm*rda.xz;
+        // step to next cell        
+        mm = step( dis.xy, dis.yx ); 
+        dis += mm*rda.xz;
         pos += mm*rds;
-	}
+    }
 
     res.x += tmin;
-    
-	return res;
+
+    return res;
 }
 #endif
-
 
 float softshadow( in vec3 ro, in vec3 rd, in float mint, in float maxt, in float k )
 {
@@ -165,9 +161,9 @@ vec3 calcNormal( in vec3 pos, in float t )
 {
     vec2 e = vec2(1.0,-1.0)*surface*t;
     return normalize( e.xyy*map( pos + e.xyy ).x + 
-					  e.yyx*map( pos + e.yyx ).x + 
-					  e.yxy*map( pos + e.yxy ).x + 
-					  e.xxx*map( pos + e.xxx ).x );
+                      e.yyx*map( pos + e.yyx ).x + 
+                      e.yxy*map( pos + e.yxy ).x + 
+                      e.xxx*map( pos + e.xxx ).x );
 }
 
 const vec3 light1 = vec3(  0.70, 0.52, -0.45 );
@@ -192,35 +188,34 @@ vec2 boundingVlume( vec2 tminmax, in vec3 ro, in vec3 rd )
     return tminmax;
 }
 
-
 vec3 doLighting( in vec3 col, in float ks,
                  in vec3 pos, in vec3 nor, in vec3 rd )
 {
     vec3  ldif = pos - lpos;
     float llen = length( ldif );
     ldif /= llen;
-	float con = dot(-light1,ldif);
-	float occ = mix( clamp( pos.y/4.0, 0.0, 1.0 ), 1.0, max(0.0,nor.y) );
+    float con = dot(-light1,ldif);
+    float occ = mix( clamp( pos.y/4.0, 0.0, 1.0 ), 1.0, max(0.0,nor.y) );
     vec2 sminmax = vec2(0.01, 5.0);
     //sminmax = boundingVlume( sminmax, pos, -ldif );
     float sha = softshadow( pos, -ldif, sminmax.x, sminmax.y, 32.0 );;
-		
+        
     float bb = smoothstep( 0.5, 0.8, con );
     float lkey = clamp( dot(nor,-ldif), 0.0, 1.0 );
-	vec3  lkat = vec3(1.0);
+    vec3  lkat = vec3(1.0);
           lkat *= vec3(bb*bb*0.6+0.4*bb,bb*0.5+0.5*bb*bb,bb).zyx;
-          lkat /= 1.0+0.25*llen*llen;		
-		  lkat *= 25.0;
+          lkat /= 1.0+0.25*llen*llen;        
+          lkat *= 25.0;
           lkat *= sha;
     float lbac = clamp( 0.1 + 0.9*dot( light2, nor ), 0.0, 1.0 );
           lbac *= smoothstep( 0.0, 0.8, con );
-		  lbac /= 1.0+0.2*llen*llen;		
-		  lbac *= 4.0;
-	float lamb = 1.0 - 0.5*nor.y;
+          lbac /= 1.0+0.2*llen*llen;        
+          lbac *= 4.0;
+    float lamb = 1.0 - 0.5*nor.y;
           lamb *= 1.0-smoothstep( 10.0, 25.0, length(pos.xz) );
-		  lamb *= 0.25 + 0.75*smoothstep( 0.0, 0.8, con );
-		  lamb *= 0.25;
-		
+          lamb *= 0.25 + 0.75*smoothstep( 0.0, 0.8, con );
+          lamb *= 0.25;
+        
     vec3 lin  = 1.0*vec3(0.20,0.05,0.02)*lamb*occ;
          lin += 1.0*vec3(1.60,0.70,0.30)*lkey*lkat*(0.5+0.5*occ);
          lin += 1.0*vec3(0.70,0.20,0.08)*lbac*occ;
@@ -229,17 +224,17 @@ vec3 doLighting( in vec3 col, in float ks,
     col = col*lin;
 
     vec3 spe = vec3(1.0)*occ*lkat*pow( clamp(dot( reflect(rd,nor), -ldif  ),0.0,1.0), 4.0 );
-	col += (0.5+0.5*ks)*0.5*spe*vec3(1.0,0.9,0.7);
+    col += (0.5+0.5*ks)*0.5*spe*vec3(1.0,0.9,0.7);
 
     return col;
 }
 
 mat3 setLookAt( in vec3 ro, in vec3 ta, float cr )
 {
-	vec3  cw = normalize(ta-ro);
-	vec3  cp = vec3(sin(cr), cos(cr),0.0);
-	vec3  cu = normalize( cross(cw,cp) );
-	vec3  cv = normalize( cross(cu,cw) );
+    vec3  cw = normalize(ta-ro);
+    vec3  cp = vec3(sin(cr), cos(cr),0.0);
+    vec3  cu = normalize( cross(cw,cp) );
+    vec3  cv = normalize( cross(cu,cw) );
     return mat3( cu, cv, cw );
 }
 
@@ -259,7 +254,7 @@ vec3 render( in vec3 ro, in vec3 rd )
         vec3 pos = ro + t*rd;
         vec3 nor = calcNormal( pos, t );
 
-        // material	
+        // material    
         col = 0.5 + 0.5*cos( 6.2831*res.y + vec3(0.0, 0.4, 0.8) );
         vec3 ff = texcube( iChannel1, 0.1*vec3(pos.x,4.0*res.z-pos.y,pos.z), nor ).xyz;
         col *= ff.x;
@@ -271,13 +266,12 @@ vec3 render( in vec3 ro, in vec3 rd )
     return col;
 }
 
-
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	freqs[0] = texture2D( iChannel0, vec2( 0.01, 0.25 ) ).x;
-	freqs[1] = texture2D( iChannel0, vec2( 0.07, 0.25 ) ).x;
-	freqs[2] = texture2D( iChannel0, vec2( 0.15, 0.25 ) ).x;
-	freqs[3] = texture2D( iChannel0, vec2( 0.30, 0.25 ) ).x;
+    freqs[0] = texture2D( iChannel0, vec2( 0.01, 0.25 ) ).x;
+    freqs[1] = texture2D( iChannel0, vec2( 0.07, 0.25 ) ).x;
+    freqs[2] = texture2D( iChannel0, vec2( 0.15, 0.25 ) ).x;
+    freqs[3] = texture2D( iChannel0, vec2( 0.30, 0.25 ) ).x;
 
     //-----------
     float time = 5.0 + 0.2*iGlobalTime + 20.0*iMouse.x/iResolution.x;
@@ -292,7 +286,7 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
     #endif        
         vec2 xy = (-iResolution.xy+2.0*(fragCoord.xy+off)) / iResolution.y;
 
-        // camera	
+        // camera    
         vec3 ro = vec3( 8.5*cos(0.2+.33*time), 5.0+2.0*cos(0.1*time), 8.5*sin(0.1+0.37*time) );
         vec3 ta = vec3( -2.5+3.0*cos(1.2+.41*time), 0.0, 2.0+3.0*sin(2.0+0.38*time) );
         float roll = 0.2*sin(0.1*time);
@@ -300,35 +294,29 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
         // camera tx
         mat3 ca = setLookAt( ro, ta, roll );
         vec3 rd = normalize( ca * vec3(xy.xy,1.75) );
-        
+
         vec3 col = render( ro, rd );
-        
+
         tot += pow( col, vec3(0.4545) );
     #ifdef ANTIALIAS
     }
-	tot /= 4.0;
+    tot /= 4.0;
     #endif    
-    
+
     // vigneting
-	vec2 q = fragCoord.xy/iResolution.xy;
+    vec2 q = fragCoord.xy/iResolution.xy;
     tot *= 0.2 + 0.8*pow( 16.0*q.x*q.y*(1.0-q.x)*(1.0-q.y), 0.1 );
 
     fragColor=vec4( tot, 1.0 );
 
-
-
-
 }
-
-
-
 
 void mainVR( out vec4 fragColor, in vec2 fragCoord, in vec3 fragRayOri, in vec3 fragRayDir )
 {
-	freqs[0] = texture2D( iChannel0, vec2( 0.01, 0.25 ) ).x;
-	freqs[1] = texture2D( iChannel0, vec2( 0.07, 0.25 ) ).x;
-	freqs[2] = texture2D( iChannel0, vec2( 0.15, 0.25 ) ).x;
-	freqs[3] = texture2D( iChannel0, vec2( 0.30, 0.25 ) ).x;
+    freqs[0] = texture2D( iChannel0, vec2( 0.01, 0.25 ) ).x;
+    freqs[1] = texture2D( iChannel0, vec2( 0.07, 0.25 ) ).x;
+    freqs[2] = texture2D( iChannel0, vec2( 0.15, 0.25 ) ).x;
+    freqs[3] = texture2D( iChannel0, vec2( 0.30, 0.25 ) ).x;
 
     vec3 col = render( fragRayOri + vec3(0.0,2.0,0.0), fragRayDir );
     fragColor = vec4( col, 1.0 );

--- a/visualization.shadertoy/resources/discotunnel.frag.glsl
+++ b/visualization.shadertoy/resources/discotunnel.frag.glsl
@@ -17,11 +17,11 @@ float tex(vec2 uv, float s)
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	vec2 uv = fragCoord.xy / iResolution.xy;
+    vec2 uv = fragCoord.xy / iResolution.xy;
     vec2 uv1 = uv * 2.0 - 1.0;
-    
+
     uv1.x *= iResolution.x / iResolution.y;
-    
+
     // Calculate new UV coordinates
     vec2 center = vec2(0.0, 0.0) + 
         vec2(0.075*(0.5 + 0.5 * sin(iGlobalTime*4.0)),
@@ -34,7 +34,7 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
     // Read the sound texture
     float sound = texture2D(iChannel0, vec2(0.01, 1.0 - r)).r;
     sound = pow(sound, 1.5);
-    
+
     // Calculate the colors
     vec3 c1 = vec3(0.02, 0.1, 0.02);
     vec3 c2 = mix( vec3(1.0, 0.6, 0.6), vec3(0.6, 0.6, 1.0), vec3(0.5 + 0.5 * sin(iGlobalTime*0.1)));
@@ -43,6 +43,5 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
     vec3 colback   = vec3(0.05,0.05,0.05);
 
     // Mix the colors
-	fragColor = vec4(r * coltunnel + (1.0 - r) * colback, 1.0);
+    fragColor = vec4(r * coltunnel + (1.0 - r) * colback, 1.0);
 }
-

--- a/visualization.shadertoy/resources/fractalland.frag.glsl
+++ b/visualization.shadertoy/resources/fractalland.frag.glsl
@@ -23,201 +23,195 @@
 #define GAMMA 1.4
 #define SATURATION .65
 
-
 #define detail .001
 #define t iGlobalTime*.5
-
 
 const vec3 origin=vec3(-1.,.7,0.);
 float det=0.0;
 
-
 // 2D rotation function
 mat2 rot(float a) {
-	return mat2(cos(a),sin(a),-sin(a),cos(a));	
+    return mat2(cos(a),sin(a),-sin(a),cos(a));    
 }
 
 // "Amazing Surface" fractal
 vec4 formula(vec4 p) {
-		p.xz = abs(p.xz+1.)-abs(p.xz-1.)-p.xz;
-		p.y-=.25;
-		p.xy*=rot(radians(35.));
-		p=p*2./clamp(dot(p.xyz,p.xyz),.2,1.);
-	return p;
+        p.xz = abs(p.xz+1.)-abs(p.xz-1.)-p.xz;
+        p.y-=.25;
+        p.xy*=rot(radians(35.));
+        p=p*2./clamp(dot(p.xyz,p.xyz),.2,1.);
+    return p;
 }
 
 // Distance function
 float de(vec3 pos) {
 #ifdef WAVES
-	pos.y+=sin(pos.z-t*6.)*.15; //waves!
+    pos.y+=sin(pos.z-t*6.)*.15; //waves!
 #endif
-	float hid=0.;
-	vec3 tpos=pos;
-	tpos.z=abs(3.-mod(tpos.z,6.));
-	vec4 p=vec4(tpos,1.);
-	for (int i=0; i<4; i++) {p=formula(p);}
-	float fr=(length(max(vec2(0.),p.yz-1.5))-1.)/p.w;
-	float ro=max(abs(pos.x+1.)-.3,pos.y-.35);
-		  ro=max(ro,-max(abs(pos.x+1.)-.1,pos.y-.5));
-	pos.z=abs(.25-mod(pos.z,.5));
-		  ro=max(ro,-max(abs(pos.z)-.2,pos.y-.3));
-		  ro=max(ro,-max(abs(pos.z)-.01,-pos.y+.32));
-	float d=min(fr,ro);
-	return d;
+    float hid=0.;
+    vec3 tpos=pos;
+    tpos.z=abs(3.-mod(tpos.z,6.));
+    vec4 p=vec4(tpos,1.);
+    for (int i=0; i<4; i++) {p=formula(p);}
+    float fr=(length(max(vec2(0.),p.yz-1.5))-1.)/p.w;
+    float ro=max(abs(pos.x+1.)-.3,pos.y-.35);
+          ro=max(ro,-max(abs(pos.x+1.)-.1,pos.y-.5));
+    pos.z=abs(.25-mod(pos.z,.5));
+          ro=max(ro,-max(abs(pos.z)-.2,pos.y-.3));
+          ro=max(ro,-max(abs(pos.z)-.01,-pos.y+.32));
+    float d=min(fr,ro);
+    return d;
 }
-
 
 // Camera path
 vec3 path(float ti) {
-	ti*=1.5;
-	vec3  p=vec3(sin(ti),(1.-sin(ti*2.))*.5,-ti*5.)*.5;
-	return p;
+    ti*=1.5;
+    vec3  p=vec3(sin(ti),(1.-sin(ti*2.))*.5,-ti*5.)*.5;
+    return p;
 }
 
 // Calc normals, and here is edge detection, set to variable "edge"
 
 float edge=0.;
 vec3 normal(vec3 p) { 
-	vec3 e = vec3(0.0,det*5.,0.0);
+    vec3 e = vec3(0.0,det*5.,0.0);
 
-	float d1=de(p-e.yxx),d2=de(p+e.yxx);
-	float d3=de(p-e.xyx),d4=de(p+e.xyx);
-	float d5=de(p-e.xxy),d6=de(p+e.xxy);
-	float d=de(p);
-	edge=abs(d-0.5*(d2+d1))+abs(d-0.5*(d4+d3))+abs(d-0.5*(d6+d5));//edge finder
-	edge=min(1.,pow(edge,.55)*15.);
-	return normalize(vec3(d1-d2,d3-d4,d5-d6));
+    float d1=de(p-e.yxx),d2=de(p+e.yxx);
+    float d3=de(p-e.xyx),d4=de(p+e.xyx);
+    float d5=de(p-e.xxy),d6=de(p+e.xxy);
+    float d=de(p);
+    edge=abs(d-0.5*(d2+d1))+abs(d-0.5*(d4+d3))+abs(d-0.5*(d6+d5));//edge finder
+    edge=min(1.,pow(edge,.55)*15.);
+    return normalize(vec3(d1-d2,d3-d4,d5-d6));
 }
-
 
 // Used Nyan Cat code by mu6k, with some mods
 
 vec4 rainbow(vec2 p)
 {
-	float q = max(p.x,-0.1);
-	float s = sin(p.x*7.0+t*70.0)*0.08;
-	p.y+=s;
-	p.y*=1.1;
-	
-	vec4 c;
-	if (p.x>0.0) c=vec4(0,0,0,0); else
-	if (0.0/6.0<p.y&&p.y<1.0/6.0) c= vec4(255,43,14,255)/255.0; else
-	if (1.0/6.0<p.y&&p.y<2.0/6.0) c= vec4(255,168,6,255)/255.0; else
-	if (2.0/6.0<p.y&&p.y<3.0/6.0) c= vec4(255,244,0,255)/255.0; else
-	if (3.0/6.0<p.y&&p.y<4.0/6.0) c= vec4(51,234,5,255)/255.0; else
-	if (4.0/6.0<p.y&&p.y<5.0/6.0) c= vec4(8,163,255,255)/255.0; else
-	if (5.0/6.0<p.y&&p.y<6.0/6.0) c= vec4(122,85,255,255)/255.0; else
-	if (abs(p.y)-.05<0.0001) c=vec4(0.,0.,0.,1.); else
-	if (abs(p.y-1.)-.05<0.0001) c=vec4(0.,0.,0.,1.); else
-		c=vec4(0,0,0,0);
-	c.a*=.8-min(.8,abs(p.x*.08));
-	c.xyz=mix(c.xyz,vec3(length(c.xyz)),.15);
-	return c;
+    float q = max(p.x,-0.1);
+    float s = sin(p.x*7.0+t*70.0)*0.08;
+    p.y+=s;
+    p.y*=1.1;
+    
+    vec4 c;
+    if (p.x>0.0) c=vec4(0,0,0,0); else
+    if (0.0/6.0<p.y&&p.y<1.0/6.0) c= vec4(255,43,14,255)/255.0; else
+    if (1.0/6.0<p.y&&p.y<2.0/6.0) c= vec4(255,168,6,255)/255.0; else
+    if (2.0/6.0<p.y&&p.y<3.0/6.0) c= vec4(255,244,0,255)/255.0; else
+    if (3.0/6.0<p.y&&p.y<4.0/6.0) c= vec4(51,234,5,255)/255.0; else
+    if (4.0/6.0<p.y&&p.y<5.0/6.0) c= vec4(8,163,255,255)/255.0; else
+    if (5.0/6.0<p.y&&p.y<6.0/6.0) c= vec4(122,85,255,255)/255.0; else
+    if (abs(p.y)-.05<0.0001) c=vec4(0.,0.,0.,1.); else
+    if (abs(p.y-1.)-.05<0.0001) c=vec4(0.,0.,0.,1.); else
+        c=vec4(0,0,0,0);
+    c.a*=.8-min(.8,abs(p.x*.08));
+    c.xyz=mix(c.xyz,vec3(length(c.xyz)),.15);
+    return c;
 }
 
 vec4 nyan(vec2 p)
 {
-	vec2 uv = p*vec2(0.4,1.0);
-	float ns=3.0;
-	float nt = iGlobalTime*ns; nt-=mod(nt,240.0/256.0/6.0); nt = mod(nt,240.0/256.0);
-	float ny = mod(iGlobalTime*ns,1.0); ny-=mod(ny,0.75); ny*=-0.05;
-	vec4 color = texture2D(iChannel1,vec2(uv.x/3.0+210.0/256.0-nt+0.05,.5-uv.y-ny));
-	if (uv.x<-0.3) color.a = 0.0;
-	if (uv.x>0.2) color.a=0.0;
-	return color;
+    vec2 uv = p*vec2(0.4,1.0);
+    float ns=3.0;
+    float nt = iGlobalTime*ns; nt-=mod(nt,240.0/256.0/6.0); nt = mod(nt,240.0/256.0);
+    float ny = mod(iGlobalTime*ns,1.0); ny-=mod(ny,0.75); ny*=-0.05;
+    vec4 color = texture2D(iChannel1,vec2(uv.x/3.0+210.0/256.0-nt+0.05,.5-uv.y-ny));
+    if (uv.x<-0.3) color.a = 0.0;
+    if (uv.x>0.2) color.a=0.0;
+    return color;
 }
-
 
 // Raymarching and 2D graphics
 
 vec3 raymarch(in vec3 from, in vec3 dir) 
 
 {
-	edge=0.;
-	vec3 p, norm;
-	float d=100.;
-	float totdist=0.;
-	for (int i=0; i<RAY_STEPS; i++) {
-		if (d>det && totdist<25.0) {
-			p=from+totdist*dir;
-			d=de(p);
-			det=detail*exp(.13*totdist);
-			totdist+=d; 
-		} 
-		else { break; }
-	}
-	vec3 col=vec3(0.);
-	p-=(det-d)*dir;
-	norm=normal(p);
+    edge=0.;
+    vec3 p, norm;
+    float d=100.;
+    float totdist=0.;
+    for (int i=0; i<RAY_STEPS; i++) {
+        if (d>det && totdist<25.0) {
+            p=from+totdist*dir;
+            d=de(p);
+            det=detail*exp(.13*totdist);
+            totdist+=d; 
+        }
+        else { break; }
+    }
+    vec3 col=vec3(0.);
+    p-=(det-d)*dir;
+    norm=normal(p);
 #ifdef SHOWONLYEDGES
-	col=1.-vec3(edge); // show wireframe version
+    col=1.-vec3(edge); // show wireframe version
 #else
-	col=(1.-abs(norm))*max(0.,1.-edge*.8); // set normal as color with dark edges
-#endif		
-	totdist=clamp(totdist,0.,26.);
-	dir.y-=.02;
-	float sunsize=7.-max(0.,texture2D(iChannel0,vec2(.6,.2)).x)*5.; // responsive sun size
-	float an=atan(dir.x,dir.y)+iGlobalTime*1.5; // angle for drawing and rotating sun
-	float s=pow(clamp(1.0-length(dir.xy)*sunsize-abs(.2-mod(an,.4)),0.,1.),.1); // sun
-	float sb=pow(clamp(1.0-length(dir.xy)*(sunsize-.2)-abs(.2-mod(an,.4)),0.,1.),.1); // sun border
-	float sg=pow(clamp(1.0-length(dir.xy)*(sunsize-4.5)-.5*abs(.2-mod(an,.4)),0.,1.),3.); // sun rays
-	float y=mix(.45,1.2,pow(smoothstep(0.,1.,.75-dir.y),2.))*(1.-sb*.5); // gradient sky
-	
-	// set up background with sky and sun
-	vec3 backg=vec3(0.5,0.,1.)*((1.-s)*(1.-sg)*y+(1.-sb)*sg*vec3(1.,.8,0.15)*3.);
-		 backg+=vec3(1.,.9,.1)*s;
-		 backg=max(backg,sg*vec3(1.,.9,.5));
-	
-	col=mix(vec3(1.,.9,.3),col,exp(-.004*totdist*totdist));// distant fading to sun color
-	if (totdist>25.) col=backg; // hit background
-	col=pow(col,vec3(GAMMA))*BRIGHTNESS;
-	col=mix(vec3(length(col)),col,SATURATION);
+    col=(1.-abs(norm))*max(0.,1.-edge*.8); // set normal as color with dark edges
+#endif        
+    totdist=clamp(totdist,0.,26.);
+    dir.y-=.02;
+    float sunsize=7.-max(0.,texture2D(iChannel0,vec2(.6,.2)).x)*5.; // responsive sun size
+    float an=atan(dir.x,dir.y)+iGlobalTime*1.5; // angle for drawing and rotating sun
+    float s=pow(clamp(1.0-length(dir.xy)*sunsize-abs(.2-mod(an,.4)),0.,1.),.1); // sun
+    float sb=pow(clamp(1.0-length(dir.xy)*(sunsize-.2)-abs(.2-mod(an,.4)),0.,1.),.1); // sun border
+    float sg=pow(clamp(1.0-length(dir.xy)*(sunsize-4.5)-.5*abs(.2-mod(an,.4)),0.,1.),3.); // sun rays
+    float y=mix(.45,1.2,pow(smoothstep(0.,1.,.75-dir.y),2.))*(1.-sb*.5); // gradient sky
+
+    // set up background with sky and sun
+    vec3 backg=vec3(0.5,0.,1.)*((1.-s)*(1.-sg)*y+(1.-sb)*sg*vec3(1.,.8,0.15)*3.);
+         backg+=vec3(1.,.9,.1)*s;
+         backg=max(backg,sg*vec3(1.,.9,.5));
+
+    col=mix(vec3(1.,.9,.3),col,exp(-.004*totdist*totdist));// distant fading to sun color
+    if (totdist>25.) col=backg; // hit background
+    col=pow(col,vec3(GAMMA))*BRIGHTNESS;
+    col=mix(vec3(length(col)),col,SATURATION);
 #ifdef SHOWONLYEDGES
-	col=1.-vec3(length(col));
+    col=1.-vec3(length(col));
 #else
-	col*=vec3(1.,.9,.85);
+    col*=vec3(1.,.9,.85);
 #ifdef NYAN
-	dir.yx*=rot(dir.x);
-	vec2 ncatpos=(dir.xy+vec2(-3.+mod(-t,6.),-.27));
-	vec4 ncat=nyan(ncatpos*5.);
-	vec4 rain=rainbow(ncatpos*10.+vec2(.8,.5));
-	if (totdist>8.) col=mix(col,max(vec3(.2),rain.xyz),rain.a*.9);
-	if (totdist>8.) col=mix(col,max(vec3(.2),ncat.xyz),ncat.a*.9);
+    dir.yx*=rot(dir.x);
+    vec2 ncatpos=(dir.xy+vec2(-3.+mod(-t,6.),-.27));
+    vec4 ncat=nyan(ncatpos*5.);
+    vec4 rain=rainbow(ncatpos*10.+vec2(.8,.5));
+    if (totdist>8.) col=mix(col,max(vec3(.2),rain.xyz),rain.a*.9);
+    if (totdist>8.) col=mix(col,max(vec3(.2),ncat.xyz),ncat.a*.9);
 #endif
 #endif
-	return col;
+    return col;
 }
 
 // get camera position
 vec3 move(inout vec3 dir) {
-	vec3 go=path(t);
-	vec3 adv=path(t+.7);
-	float hd=de(adv);
-	vec3 advec=normalize(adv-go);
-	float an=adv.x-go.x; an*=min(1.,abs(adv.z-go.z))*sign(adv.z-go.z)*.7;
-	dir.xy*=mat2(cos(an),sin(an),-sin(an),cos(an));
+    vec3 go=path(t);
+    vec3 adv=path(t+.7);
+    float hd=de(adv);
+    vec3 advec=normalize(adv-go);
+    float an=adv.x-go.x; an*=min(1.,abs(adv.z-go.z))*sign(adv.z-go.z)*.7;
+    dir.xy*=mat2(cos(an),sin(an),-sin(an),cos(an));
     an=advec.y*1.7;
-	dir.yz*=mat2(cos(an),sin(an),-sin(an),cos(an));
-	an=atan(advec.x,advec.z);
-	dir.xz*=mat2(cos(an),sin(an),-sin(an),cos(an));
-	return go;
+    dir.yz*=mat2(cos(an),sin(an),-sin(an),cos(an));
+    an=atan(advec.x,advec.z);
+    dir.xz*=mat2(cos(an),sin(an),-sin(an),cos(an));
+    return go;
 }
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	vec2 uv = fragCoord.xy / iResolution.xy*2.-1.;
-	vec2 oriuv=uv;
-	uv.y*=iResolution.y/iResolution.x;
-	vec2 mouse=(iMouse.xy/iResolution.xy-.5)*3.;
-	if (iMouse.z<1.) mouse=vec2(0.,-0.05);
-	float fov=.9-max(0.,.7-iGlobalTime*.3);
-	vec3 dir=normalize(vec3(uv*fov,1.));
-	dir.yz*=rot(mouse.y);
-	dir.xz*=rot(mouse.x);
-	vec3 from=origin+move(dir);
-	vec3 color=raymarch(from,dir); 
-	#ifdef BORDER
-	color=mix(vec3(0.),color,pow(max(0.,.95-length(oriuv*oriuv*oriuv*vec2(1.05,1.1))),.3));
-	#endif
-	fragColor = vec4(color,1.);
+    vec2 uv = fragCoord.xy / iResolution.xy*2.-1.;
+    vec2 oriuv=uv;
+    uv.y*=iResolution.y/iResolution.x;
+    vec2 mouse=(iMouse.xy/iResolution.xy-.5)*3.;
+    if (iMouse.z<1.) mouse=vec2(0.,-0.05);
+    float fov=.9-max(0.,.7-iGlobalTime*.3);
+    vec3 dir=normalize(vec3(uv*fov,1.));
+    dir.yz*=rot(mouse.y);
+    dir.xz*=rot(mouse.x);
+    vec3 from=origin+move(dir);
+    vec3 color=raymarch(from,dir); 
+    #ifdef BORDER
+    color=mix(vec3(0.),color,pow(max(0.,.95-length(oriuv*oriuv*oriuv*vec2(1.05,1.1))),.3));
+    #endif
+    fragColor = vec4(color,1.);
 }

--- a/visualization.shadertoy/resources/gameboy.frag.glsl
+++ b/visualization.shadertoy/resources/gameboy.frag.glsl
@@ -6,85 +6,85 @@
 float text( vec2 p ) 
 {
     // trick for encoding fonts from CPU
-	p.x += 0.2*floor(10.0*(0.5+0.5*sin(iGlobalTime)))/10.0;
-	
-	float x = floor( p.x*100.0 ) - 23.0;
-	float y = floor( p.y*100.0 ) - 82.0;
+    p.x += 0.2*floor(10.0*(0.5+0.5*sin(iGlobalTime)))/10.0;
+    
+    float x = floor( p.x*100.0 ) - 23.0;
+    float y = floor( p.y*100.0 ) - 82.0;
 
-	if( y<0.0 || y> 5.0) return 0.0;
-	if( x<0.0 || x>70.0) return 0.0;
-	
+    if( y<0.0 || y> 5.0) return 0.0;
+    if( x<0.0 || x>70.0) return 0.0;
+    
     float v = 0.0;
-	
+    
          if( x>63.5 ) {           v=12288.0;
-	                    if(y>2.5) v=30720.0;
-	                    if(y>3.5) v=52224.0; }
-	else if( x>47.5 ) {           v=12408.0;
-	                    if(y>0.5) v=12492.0;
-	                    if(y>4.5) v=64632.0; }
-	else if( x>31.5 ) {           v=64716.0;
-	                    if(y>0.5) v=49360.0;
-	                    if(y>1.5) v=49400.0;
-	                    if(y>2.5) v=63692.0;
-	                    if(y>3.5) v=49356.0;
-	                    if(y>4.5) v=64760.0; }
-	else if( x>15.5 ) {           v=40184.0;
-	                    if(y>0.5) v=40092.0;
-	                    if(y>2.5) v=64668.0;
-	                    if(y>3.5) v=40092.0;
-	                    if(y>4.5) v=28920.0; }
-	else	          {           v=30860.0;
-    	                if(y>0.5) v=40076.0;
-    	                if(y>1.5) v= 7308.0;
-    	                if(y>2.5) v=30972.0;
-    	                if(y>3.5) v=49292.0;
-    	                if(y>4.5) v=30860.0; }
-		
-	return floor( mod(v/pow(2.0,15.0-mod( x, 16.0 )), 2.0) );
+                        if(y>2.5) v=30720.0;
+                        if(y>3.5) v=52224.0; }
+    else if( x>47.5 ) {           v=12408.0;
+                        if(y>0.5) v=12492.0;
+                        if(y>4.5) v=64632.0; }
+    else if( x>31.5 ) {           v=64716.0;
+                        if(y>0.5) v=49360.0;
+                        if(y>1.5) v=49400.0;
+                        if(y>2.5) v=63692.0;
+                        if(y>3.5) v=49356.0;
+                        if(y>4.5) v=64760.0; }
+    else if( x>15.5 ) {           v=40184.0;
+                        if(y>0.5) v=40092.0;
+                        if(y>2.5) v=64668.0;
+                        if(y>3.5) v=40092.0;
+                        if(y>4.5) v=28920.0; }
+    else              {           v=30860.0;
+                        if(y>0.5) v=40076.0;
+                        if(y>1.5) v= 7308.0;
+                        if(y>2.5) v=30972.0;
+                        if(y>3.5) v=49292.0;
+                        if(y>4.5) v=30860.0; }
+        
+    return floor( mod(v/pow(2.0,15.0-mod( x, 16.0 )), 2.0) );
 }
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	vec2 uv = fragCoord.xy / iResolution.xy;
+    vec2 uv = fragCoord.xy / iResolution.xy;
     vec2 uvo = uv;
     
-	vec2 res = floor( 60.0*vec2(1.0,iResolution.y/iResolution.x) );
-	
-	vec3 col = vec3(131.0, 145.0, 0.0);
-	if( uv.x>0.03 && uv.x<0.97 )
-	{
-		uv.x = clamp( (uv.x-0.03)/0.94, 0.0, 1.0 );
-		
+    vec2 res = floor( 60.0*vec2(1.0,iResolution.y/iResolution.x) );
+    
+    vec3 col = vec3(131.0, 145.0, 0.0);
+    if( uv.x>0.03 && uv.x<0.97 )
+    {
+        uv.x = clamp( (uv.x-0.03)/0.94, 0.0, 1.0 );
+        
         vec2 iuv = floor( uv * res )/res;
-	
+    
         float f = 1.0-abs(-1.0+2.0*fract( uv.x * res.x ));
         float g = 1.0-abs(-1.0+2.0*fract( uv.y * res.y ));
-	
-    	float fft = texture2D( iChannel0, vec2(iuv.x,0.25) ).x; 
-		fft = 0.8*fft*fft;
+    
+        float fft = texture2D( iChannel0, vec2(iuv.x,0.25) ).x; 
+        fft = 0.8*fft*fft;
         if( iuv.y<fft )
         {
-		    if( f>0.1 && g>0.1 ) col = vec3(40.0,44.0,4.0);
-		    if( f>0.5 && g>0.5 ) col = vec3(74.0,82.0,4.0);
+            if( f>0.1 && g>0.1 ) col = vec3(40.0,44.0,4.0);
+            if( f>0.5 && g>0.5 ) col = vec3(74.0,82.0,4.0);
         }
-		
+        
 
         float wave = texture2D( iChannel0, vec2(iuv.x*0.5,0.75) ).x;
         if( abs(iuv.y-wave)<=(1.0/res.y) )
         {
-	        col = vec3(185.0, 200.0, 90.0);
+            col = vec3(185.0, 200.0, 90.0);
         }
 
-		float t = text( uvo );
-		col = mix( col, vec3(40.0,44.0,4.0), t );
-	}
-	else
-	{
-		float g = 1.0-abs(-1.0+2.0*fract( uv.y * res.y*1.5 ));
-		float f = 1.0-abs(-1.0+2.0*fract( uv.x * res.x + 0.5*floor(uv.y*res.y*1.5)));
+        float t = text( uvo );
+        col = mix( col, vec3(40.0,44.0,4.0), t );
+    }
+    else
+    {
+        float g = 1.0-abs(-1.0+2.0*fract( uv.y * res.y*1.5 ));
+        float f = 1.0-abs(-1.0+2.0*fract( uv.x * res.x + 0.5*floor(uv.y*res.y*1.5)));
 
-		if( g<0.15 || f<0.15 ) col = vec3(40.0,44.0,4.0);
-	}
+        if( g<0.15 || f<0.15 ) col = vec3(40.0,44.0,4.0);
+    }
 
-	fragColor = vec4( col/255.0,1.0 );
+    fragColor = vec4( col/255.0,1.0 );
 }

--- a/visualization.shadertoy/resources/io.frag.glsl
+++ b/visualization.shadertoy/resources/io.frag.glsl
@@ -5,12 +5,12 @@
 
 float rand(float x)
 {
-    return fract(sin(x) * 4358.5453123);
+  return fract(sin(x) * 4358.5453123);
 }
 
 float rand(vec2 co)
 {
-    return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5357);
+  return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5357);
 }
 
 float box(vec2 p, vec2 b, float r)
@@ -20,50 +20,50 @@ float box(vec2 p, vec2 b, float r)
 
 float sampleMusic()
 {
-	return 0.5 * (
-		//texture2D( iChannel0, vec2( 0.01, 0.25 ) ).x + 
-		//texture2D( iChannel0, vec2( 0.07, 0.25 ) ).x + 
-		texture2D( iChannel0, vec2( 0.15, 0.25 ) ).x + 
-		texture2D( iChannel0, vec2( 0.30, 0.25 ) ).x);
+  return 0.5 * (
+  //texture2D( iChannel0, vec2( 0.01, 0.25 ) ).x +
+  //texture2D( iChannel0, vec2( 0.07, 0.25 ) ).x);
+  texture2D( iChannel0, vec2( 0.15, 0.25 ) ).x +
+  texture2D( iChannel0, vec2( 0.30, 0.25 ) ).x);
 }
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	const float speed = 0.7;
-	const float ySpread = 1.6;
-	const int numBlocks = 70;
+    const float speed = 0.7;
+    const float ySpread = 1.6;
+    const int numBlocks = 70;
 
-	float pulse = sampleMusic();
-	
-	vec2 uv = fragCoord.xy / iResolution.xy - 0.5;
-	float aspect = iResolution.x / iResolution.y;
-	vec3 baseColor = uv.x > 0.0 ? vec3(0.0,0.3, 0.6) : vec3(0.6, 0.0, 0.3);
-	
-	vec3 color = pulse*baseColor*0.5*(0.9-cos(uv.x*8.0));
-	uv.x *= aspect;
-	
-	for (int i = 0; i < numBlocks; i++)
-	{
-		float z = 1.0-0.7*rand(float(i)*1.4333); // 0=far, 1=near
-		float tickTime = iGlobalTime*z*speed + float(i)*1.23753;
-		float tick = floor(tickTime);
-		
-		vec2 pos = vec2(0.6*aspect*(rand(tick)-0.5), sign(uv.x)*ySpread*(0.5-fract(tickTime)));
-		pos.x += 0.24*sign(pos.x); // move aside
-		if (abs(pos.x) < 0.1) pos.x++; // stupid fix; sign sometimes returns 0
-		
-		vec2 size = 1.8*z*vec2(0.04, 0.04 + 0.1*rand(tick+0.2));
-		float b = box(uv-pos, size, 0.01);
-		float dust = z*smoothstep(0.22, 0.0, b)*pulse*0.5;
-		#ifdef SHOW_BLOCKS
-		float block = 0.2*z*smoothstep(0.002, 0.0, b);
-		float shine = 0.6*z*pulse*smoothstep(-0.002, b, 0.007);
-		color += dust*baseColor + block*z + shine;
-		#else
-		color += dust*baseColor;
-		#endif
-	}
-	
-	color -= rand(uv)*0.04;
-	fragColor = vec4(color, 1.0);
+    float pulse = sampleMusic();
+
+    vec2 uv = fragCoord.xy / iResolution.xy - 0.5;
+    float aspect = iResolution.x / iResolution.y;
+    vec3 baseColor = uv.x > 0.0 ? vec3(0.0,0.3, 0.6) : vec3(0.6, 0.0, 0.3);
+
+    vec3 color = pulse*baseColor*0.5*(0.9-cos(uv.x*8.0));
+    uv.x *= aspect;
+
+    for (int i = 0; i < numBlocks; i++)
+    {
+        float z = 1.0-0.7*rand(float(i)*1.4333); // 0=far, 1=near
+        float tickTime = iGlobalTime*z*speed + float(i)*1.23753;
+        float tick = floor(tickTime);
+
+        vec2 pos = vec2(0.6*aspect*(rand(tick)-0.5), sign(uv.x)*ySpread*(0.5-fract(tickTime)));
+        pos.x += 0.24*sign(pos.x); // move aside
+        if (abs(pos.x) < 0.1) pos.x++; // stupid fix; sign sometimes returns 0
+
+        vec2 size = 1.8*z*vec2(0.04, 0.04 + 0.1*rand(tick+0.2));
+        float b = box(uv-pos, size, 0.01);
+        float dust = z*smoothstep(0.22, 0.0, b)*pulse*0.5;
+        #ifdef SHOW_BLOCKS
+        float block = 0.2*z*smoothstep(0.002, 0.0, b);
+        float shine = 0.6*z*pulse*smoothstep(-0.002, b, 0.007);
+        color += dust*baseColor + block*z + shine;
+        #else
+        color += dust*baseColor;
+        #endif
+    }
+
+    color -= rand(uv)*0.04;
+    fragColor = vec4(color, 1.0);
 }

--- a/visualization.shadertoy/resources/nyancat.frag.glsl
+++ b/visualization.shadertoy/resources/nyancat.frag.glsl
@@ -1,7 +1,7 @@
 // Taken from https://www.shadertoy.com/view/4dXGWH
 
 /*by mu6k, Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
- 
+
  I started animating the nyancat image. I looked up the original colors 
  for rainbow and background. I kept adding stuff until I ended up with 
  something I could watch for 10 hours. Nah 10 hours is too long... or is it? 
@@ -24,218 +24,212 @@
 
 float hash(float x)
 {
-	return fract(sin(x*.0127863)*17143.321);
+    return fract(sin(x*.0127863)*17143.321);
 }
 
 float hash(vec2 x)
 {
-	return fract(sin(dot(x,vec2(1.4,52.14)))*17143.321);
+    return fract(sin(dot(x,vec2(1.4,52.14)))*17143.321);
 }
 
 
 float hashmix(float x0, float x1, float interp)
 {
-	x0 = hash(x0);
-	x1 = hash(x1);
-	#ifdef noise_use_smoothstep
-	interp = smoothstep(0.0,1.0,interp);
-	#endif
-	return mix(x0,x1,interp);
+    x0 = hash(x0);
+    x1 = hash(x1);
+    #ifdef noise_use_smoothstep
+    interp = smoothstep(0.0,1.0,interp);
+    #endif
+    return mix(x0,x1,interp);
 }
 
 float hashmix(vec2 p0, vec2 p1, vec2 interp)
 {
-	float v0 = hashmix(p0[0]+p0[1]*128.0,p1[0]+p0[1]*128.0,interp[0]);
-	float v1 = hashmix(p0[0]+p1[1]*128.0,p1[0]+p1[1]*128.0,interp[0]);
-	#ifdef noise_use_smoothstep
-	interp = smoothstep(vec2(0.0),vec2(1.0),interp);
-	#endif
-	return mix(v0,v1,interp[1]);
+    float v0 = hashmix(p0[0]+p0[1]*128.0,p1[0]+p0[1]*128.0,interp[0]);
+    float v1 = hashmix(p0[0]+p1[1]*128.0,p1[0]+p1[1]*128.0,interp[0]);
+    #ifdef noise_use_smoothstep
+    interp = smoothstep(vec2(0.0),vec2(1.0),interp);
+    #endif
+    return mix(v0,v1,interp[1]);
 }
 
 float hashmix(vec3 p0, vec3 p1, vec3 interp)
 {
-	float v0 = hashmix(p0.xy+vec2(p0.z*43.0,0.0),p1.xy+vec2(p0.z*43.0,0.0),interp.xy);
-	float v1 = hashmix(p0.xy+vec2(p1.z*43.0,0.0),p1.xy+vec2(p1.z*43.0,0.0),interp.xy);
-	#ifdef noise_use_smoothstep
-	interp = smoothstep(vec3(0.0),vec3(1.0),interp);
-	#endif
-	return mix(v0,v1,interp[2]);
+    float v0 = hashmix(p0.xy+vec2(p0.z*43.0,0.0),p1.xy+vec2(p0.z*43.0,0.0),interp.xy);
+    float v1 = hashmix(p0.xy+vec2(p1.z*43.0,0.0),p1.xy+vec2(p1.z*43.0,0.0),interp.xy);
+    #ifdef noise_use_smoothstep
+    interp = smoothstep(vec3(0.0),vec3(1.0),interp);
+    #endif
+    return mix(v0,v1,interp[2]);
 }
 
 float hashmix(vec4 p0, vec4 p1, vec4 interp)
 {
-	float v0 = hashmix(p0.xyz+vec3(p0.w*17.0,0.0,0.0),p1.xyz+vec3(p0.w*17.0,0.0,0.0),interp.xyz);
-	float v1 = hashmix(p0.xyz+vec3(p1.w*17.0,0.0,0.0),p1.xyz+vec3(p1.w*17.0,0.0,0.0),interp.xyz);
-	#ifdef noise_use_smoothstep
-	interp = smoothstep(vec4(0.0),vec4(1.0),interp);
-	#endif
-	return mix(v0,v1,interp[3]);
+    float v0 = hashmix(p0.xyz+vec3(p0.w*17.0,0.0,0.0),p1.xyz+vec3(p0.w*17.0,0.0,0.0),interp.xyz);
+    float v1 = hashmix(p0.xyz+vec3(p1.w*17.0,0.0,0.0),p1.xyz+vec3(p1.w*17.0,0.0,0.0),interp.xyz);
+    #ifdef noise_use_smoothstep
+    interp = smoothstep(vec4(0.0),vec4(1.0),interp);
+    #endif
+    return mix(v0,v1,interp[3]);
 }
 
 float noise(float p)
 {
-	float pm = mod(p,1.0);
-	float pd = p-pm;
-	return hashmix(pd,pd+1.0,pm);
+    float pm = mod(p,1.0);
+    float pd = p-pm;
+    return hashmix(pd,pd+1.0,pm);
 }
 
 float noise(vec2 p)
 {
-	vec2 pm = mod(p,1.0);
-	vec2 pd = p-pm;
-	return hashmix(pd,(pd+vec2(1.0,1.0)), pm);
+    vec2 pm = mod(p,1.0);
+    vec2 pd = p-pm;
+    return hashmix(pd,(pd+vec2(1.0,1.0)), pm);
 }
 
 float noise(vec3 p)
 {
-	vec3 pm = mod(p,1.0);
-	vec3 pd = p-pm;
-	return hashmix(pd,(pd+vec3(1.0,1.0,1.0)), pm);
+    vec3 pm = mod(p,1.0);
+    vec3 pd = p-pm;
+    return hashmix(pd,(pd+vec3(1.0,1.0,1.0)), pm);
 }
 
 float noise(vec4 p)
 {
-	vec4 pm = mod(p,1.0);
-	vec4 pd = p-pm;
-	return hashmix(pd,(pd+vec4(1.0,1.0,1.0,1.0)), pm);
+    vec4 pm = mod(p,1.0);
+    vec4 pd = p-pm;
+    return hashmix(pd,(pd+vec4(1.0,1.0,1.0,1.0)), pm);
 }
 
 vec3 background(vec2 p)
 {
-	vec2 pm = mod(p,vec2(0.5));
-	float q = pm.x+pm.y;
-	vec3 color = vec3(13,66,121)/255.0;
-	
-	vec2 visuv = p*0.5;
-	vec2 visuvm = mod(visuv,vec2(0.05,0.05));
-	visuv-=visuvm;
-	float vis = texture2D(iChannel0,vec2((visuv.x+1.0)*.5,0.0)).y*2.0-visuv.y;
-	
-	if (vis>1.0&&visuvm.x<0.04&&visuvm.y<0.04)
-		color.xyz *=0.85;
-	
-	vec2 p2;
-	float stars;
-	for (int i=0; i<5; i++)
-	{
-		float s = float(i)*0.2+1.0;
-		//float ts
-		p2=p*s+vec2(iGlobalTime/s,s*16.0)-mod(p*s+vec2(iGlobalTime/s,s*16.0),vec2(0.05));
-		stars=noise(p2*16.0);
-		if (stars>0.98) color=vec3(1.0,1.0,1.0);
-	}
-	
-	vec2 visuv2 = p*0.25+vec2(iGlobalTime*0.1,0);
-	vec2 visuvm2 = mod(visuv2,vec2(0.05,0.05));
-	visuv2-=visuvm2;
-	
-	float vis2p = hash(visuv2);
-	float vis2 = texture2D(iChannel0,vec2(vis2p,0)).y;
-	
-	vis2 = pow(vis2,20.0)*261.0;
-	vis2 *= vis2p;
-	
-	if (vis2>1.0) vis2=1.0;
-	
-	if (vis2>0.2&&visuvm2.x<0.09&&visuvm2.y<0.09)
-		color+=vec3(vis2,vis2,vis2)*0.5;
-	
-	return color;
+    vec2 pm = mod(p,vec2(0.5));
+    float q = pm.x+pm.y;
+    vec3 color = vec3(13,66,121)/255.0;
+
+    vec2 visuv = p*0.5;
+    vec2 visuvm = mod(visuv,vec2(0.05,0.05));
+    visuv-=visuvm;
+    float vis = texture2D(iChannel0,vec2((visuv.x+1.0)*.5,0.0)).y*2.0-visuv.y;
+
+    if (vis>1.0&&visuvm.x<0.04&&visuvm.y<0.04)
+        color.xyz *=0.85;
+
+    vec2 p2;
+    float stars;
+    for (int i=0; i<5; i++)
+    {
+        float s = float(i)*0.2+1.0;
+        //float ts
+        p2=p*s+vec2(iGlobalTime/s,s*16.0)-mod(p*s+vec2(iGlobalTime/s,s*16.0),vec2(0.05));
+        stars=noise(p2*16.0);
+        if (stars>0.98) color=vec3(1.0,1.0,1.0);
+    }
+
+    vec2 visuv2 = p*0.25+vec2(iGlobalTime*0.1,0);
+    vec2 visuvm2 = mod(visuv2,vec2(0.05,0.05));
+    visuv2-=visuvm2;
+
+    float vis2p = hash(visuv2);
+    float vis2 = texture2D(iChannel0,vec2(vis2p,0)).y;
+
+    vis2 = pow(vis2,20.0)*261.0;
+    vis2 *= vis2p;
+
+    if (vis2>1.0) vis2=1.0;
+
+    if (vis2>0.2&&visuvm2.x<0.09&&visuvm2.y<0.09)
+        color+=vec3(vis2,vis2,vis2)*0.5;
+
+    return color;
 }
 
 vec4 rainbow(vec2 p)
 {
-	
-	p.x-=mod(p.x,0.05);
-	float q = max(p.x,-0.1);
-	float s = sin(p.x*(8.0)+iGlobalTime*8.0)*0.09;
-	s-=mod(s,0.05);
-	p.y+=s;
-	
-	
-//p.y += sin(p.x*8.0+iGlobalTime)*0.25;
-	
-	vec4 c;
-	
-	if (p.x>0.0) c=vec4(0,0,0,0); else
-	if (0.0/6.0<p.y&&p.y<1.0/6.0) c= vec4(255,43,14,255)/255.0; else
-	if (1.0/6.0<p.y&&p.y<2.0/6.0) c= vec4(255,168,6,255)/255.0; else
-	if (2.0/6.0<p.y&&p.y<3.0/6.0) c= vec4(255,244,0,255)/255.0; else
-	if (3.0/6.0<p.y&&p.y<4.0/6.0) c= vec4(51,234,5,255)/255.0; else
-	if (4.0/6.0<p.y&&p.y<5.0/6.0) c= vec4(8,163,255,255)/255.0; else
-	if (5.0/6.0<p.y&&p.y<6.0/6.0) c= vec4(122,85,255,255)/255.0; else
-		c=vec4(0,0,0,0);
-	return c;
+    p.x-=mod(p.x,0.05);
+    float q = max(p.x,-0.1);
+    float s = sin(p.x*(8.0)+iGlobalTime*8.0)*0.09;
+    s-=mod(s,0.05);
+    p.y+=s;
+
+    //p.y += sin(p.x*8.0+iGlobalTime)*0.25;
+
+    vec4 c;
+
+    if (p.x>0.0) c=vec4(0,0,0,0); else
+    if (0.0/6.0<p.y&&p.y<1.0/6.0) c= vec4(255,43,14,255)/255.0; else
+    if (1.0/6.0<p.y&&p.y<2.0/6.0) c= vec4(255,168,6,255)/255.0; else
+    if (2.0/6.0<p.y&&p.y<3.0/6.0) c= vec4(255,244,0,255)/255.0; else
+    if (3.0/6.0<p.y&&p.y<4.0/6.0) c= vec4(51,234,5,255)/255.0; else
+    if (4.0/6.0<p.y&&p.y<5.0/6.0) c= vec4(8,163,255,255)/255.0; else
+    if (5.0/6.0<p.y&&p.y<6.0/6.0) c= vec4(122,85,255,255)/255.0; else
+        c=vec4(0,0,0,0);
+    return c;
 }
 
 vec4 nyan(vec2 p)
 {
-	vec2 uv = p*vec2(0.4,1.0);
-	float ns=2.0;
-	float nt = iGlobalTime*ns; nt-=mod(nt,240.0/256.0/6.0); nt = mod(nt,240.0/256.0);
-	float ny = mod(iGlobalTime*ns,1.0); ny-=mod(ny,0.75); ny*=-0.05;
-	vec4 color = texture2D(iChannel1,vec2(uv.x/3.0+210.0/256.0-nt+0.05,.5-uv.y-ny));
-	if (uv.x<-0.3) color.a = 0.0;
-	if (uv.x>0.2) color.a=0.0;
-	return color;
+    vec2 uv = p*vec2(0.4,1.0);
+    float ns=2.0;
+    float nt = iGlobalTime*ns; nt-=mod(nt,240.0/256.0/6.0); nt = mod(nt,240.0/256.0);
+    float ny = mod(iGlobalTime*ns,1.0); ny-=mod(ny,0.75); ny*=-0.05;
+    vec4 color = texture2D(iChannel1,vec2(uv.x/3.0+210.0/256.0-nt+0.05,.5-uv.y-ny));
+    if (uv.x<-0.3) color.a = 0.0;
+    if (uv.x>0.2) color.a=0.0;
+    return color;
 }
 
 vec4 scene(vec2 uv)
 {
-	
-	vec4 color = nyan(uv);
-	vec3 c2 = background(uv+vec2(0,0));
-	vec4 c3 = rainbow(vec2(uv.x+0.4,0.05-uv.y*2.0+.5));
-	
-	vec4 c4 = mix(vec4(c2,1.0),c3,c3.a);
-		
-	color = mix(c4,color,color[3]);
-	return color;
+    vec4 color = nyan(uv);
+    vec3 c2 = background(uv+vec2(0,0));
+    vec4 c3 = rainbow(vec2(uv.x+0.4,0.05-uv.y*2.0+.5));
+    
+    vec4 c4 = mix(vec4(c2,1.0),c3,c3.a);
+        
+    color = mix(c4,color,color[3]);
+    return color;
 }
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	float vol = .0;
-	for(float x = 0.0; x<1.0; x+=1.0/256.0)
-	{
-		vol += texture2D(iChannel0,vec2(x,0.0)).y;
-	}
-	vol*=1.0/256.0;
-	vol = pow(vol,16.0)*256.0;
-	
-	
-	vec2 uv = fragCoord.xy / iResolution.xy-0.5;
-	uv.x*=iResolution.x/iResolution.y;
-	vec2 ouv=uv;
-	float t = iGlobalTime-length(uv)*0.5;
-	
-	uv.x+=sin(t*0.4)*0.05;
-	uv.y+=cos(t)*0.05;
+    float vol = .0;
+    for(float x = 0.0; x<1.0; x+=1.0/256.0)
+    {
+        vol += texture2D(iChannel0,vec2(x,0.0)).y;
+    }
+    vol*=1.0/256.0;
+    vol = pow(vol,16.0)*256.0;
 
-	
-	float angle = (cos(t*0.461)+cos(t*0.71)+cos(t*0.342)+cos(t*0.512))*0.2;
-	angle+=sin(t*16.0)*vol*0.1;
-	float zoom = (cos(t*0.364)+cos(t*0.686)+cos(t*0.286)+cos(t*0.496))*0.2;
-	uv*=pow(2.0,zoom+1.0-vol*4.0);
-	uv=uv*mat2(cos(angle),-sin(angle),sin(angle),cos(angle));
-	
-	
-	vec4 color = vec4(0);
-	
-	uv.y+=vol;
+    vec2 uv = fragCoord.xy / iResolution.xy-0.5;
+    uv.x*=iResolution.x/iResolution.y;
+    vec2 ouv=uv;
+    float t = iGlobalTime-length(uv)*0.5;
 
-	for(int x = 0; x<quality; x++)
-	for(int y = 0; y<quality; y++)
-	{
-		float xx = float(x)*2.0/float(quality)/iResolution.y;
-		float yy = float(y)*2.0/float(quality)/iResolution.y;
-		float n = hash(color.xy+ouv+vec2(float(x),float(y)));
-		float s = 1.0-pow(n,10.0)*vol*17.0;
-		color += scene((uv+vec2(xx,yy))*s)/float(quality*quality)*(1.0+vol);
-	}
+    uv.x+=sin(t*0.4)*0.05;
+    uv.y+=cos(t)*0.05;
 
-	color-=vec4(length(uv)*0.05);
-	color.xyz+=vec3(hash(color.xy+ouv))*0.02;
-	fragColor = color;
+    float angle = (cos(t*0.461)+cos(t*0.71)+cos(t*0.342)+cos(t*0.512))*0.2;
+    angle+=sin(t*16.0)*vol*0.1;
+    float zoom = (cos(t*0.364)+cos(t*0.686)+cos(t*0.286)+cos(t*0.496))*0.2;
+    uv*=pow(2.0,zoom+1.0-vol*4.0);
+    uv=uv*mat2(cos(angle),-sin(angle),sin(angle),cos(angle));
+
+    vec4 color = vec4(0);
+
+    uv.y+=vol;
+
+    for(int x = 0; x<quality; x++)
+    for(int y = 0; y<quality; y++)
+    {
+        float xx = float(x)*2.0/float(quality)/iResolution.y;
+        float yy = float(y)*2.0/float(quality)/iResolution.y;
+        float n = hash(color.xy+ouv+vec2(float(x),float(y)));
+        float s = 1.0-pow(n,10.0)*vol*17.0;
+        color += scene((uv+vec2(xx,yy))*s)/float(quality*quality)*(1.0+vol);
+    }
+
+    color-=vec4(length(uv)*0.05);
+    color.xyz+=vec3(hash(color.xy+ouv))*0.02;
+    fragColor = color;
 }

--- a/visualization.shadertoy/resources/polarbeats.frag.glsl
+++ b/visualization.shadertoy/resources/polarbeats.frag.glsl
@@ -8,58 +8,57 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
     // aspect ratio
     float a = iResolution.x/iResolution.y;
-    
+
     // position of screen
     // dom x = [0.0, 1.0]
     // dom y = [0.0, 1.0]
     // origin is at bottom left corner
-	vec2 uv = fragCoord.xy / iResolution.xy;
-    
+    vec2 uv = fragCoord.xy / iResolution.xy;
+
     // multiply aspect ratio to remove distortions
     uv.x *= a;
-    
+
     // align polar graph to center of screen
     vec2 q = uv - vec2(0.5*a, 0.5);
-    
+
     // fft values, look at the bars at the bottom of the screen
     float fft = texture2D(iChannel0, vec2(0.0, 0.)).x;
     float fft2 = texture2D(iChannel0, vec2(1., 0.)).x;
     float fft3 = texture2D(iChannel0, vec2(0.5, 0.)).x;
-    
+
     // theta value
     float t = atan(q.y, q.x);
-    
+
     // time from start of song
     float ts = iChannelTime[0];
-    
+
     // the main polar graph, r = ...
     float r = pow(fft*2.-0.5, 2.)*cos(6.*t + (fft2*1.5 + ts)*5.) + 2.0 + pow(fft, 2.);
     r *= fft/12. + 0.04;
-    
+
     vec2 p = q;
     #ifdef FILTER
         p.x += sin(q.y*5000.)/100.;
         p.y += cos(q.x*5000.)/100.;
     #endif
-    
-    
+
     // bg
     vec3 col = vec3(smoothstep(r, r + fft*0.02 + 0.01, length(p)));
     #ifdef GLOW
-    	col *= 1.*smoothstep(0., r + fft*0.2, length(q));
+        col *= 1.*smoothstep(0., r + fft*0.2, length(q));
     #endif
-    
+
     col.r = clamp(col.r, 0.0, 1.0);
     col.g = clamp(col.g, 0.0, 1.0);
     col.b = clamp(col.b, 0.0, 1.0);
-    
+
     // fg
     vec3 col2 = 1.0 - col;
 
     // bg
     // radial gradient
     col -= 0.5*smoothstep(0.0, 2., length(q/(fft + 0.5)));
-    
+
     #ifdef LIGHT_SOURCE
         // give a more red warm light colour
         col.g *= 0.97;
@@ -68,9 +67,9 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
         // cool lighting effect
         col += uv.y/16.;
     #endif
-    
+
     #ifdef FILTER
-    	col += sin(50.*q.y - ts*3.)*(fft*0.5+0.5)*0.05 - 0.1*(fft*0.3+0.5)*abs(-2.*q.x*sin(q.y*1000. - ts*5.));
+        col += sin(50.*q.y - ts*3.)*(fft*0.5+0.5)*0.05 - 0.1*(fft*0.3+0.5)*abs(-2.*q.x*sin(q.y*1000. - ts*5.));
     #endif // FILTER
 
     // fg
@@ -79,10 +78,10 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
     // radial gradient for polar graph.
     // removing this will change the polar graph to a solid colour
     col2 *= length(q)*0.5 + 0.85;
-    
+
     // add fg to bg
     col += col2;
-    
+
     // volia!
-	fragColor = vec4(col,1.0);
+    fragColor = vec4(col,1.0);
 }

--- a/visualization.shadertoy/resources/ribbons.frag.glsl
+++ b/visualization.shadertoy/resources/ribbons.frag.glsl
@@ -1,6 +1,5 @@
 // Taken from https://www.shadertoy.com/view/lds3zr
 
-
 //-----------------------------------------------------------------------------
 // Utils
 //-----------------------------------------------------------------------------
@@ -32,40 +31,44 @@ vec3 rotateZ(vec3 v, float x)
         v.z
     );
 }
+
 //-----------------------------------------------------------------------------
 // Scene/Objects
 //-----------------------------------------------------------------------------
 float box(vec3 p, vec3 pos, vec3 size)
 {
-	return max(max(abs(p.x-pos.x)-size.x,abs(p.y-pos.y)-size.y),abs(p.z-pos.z)-size.z);
+    return max(max(abs(p.x-pos.x)-size.x,abs(p.y-pos.y)-size.y),abs(p.z-pos.z)-size.z);
 }
-
 
 float ribbon1(vec3 p)
 {
-	return box(p,vec3(cos(p.z)*.5,sin(p.z+p.x)*.5,.0),vec3(.02,0.02,3.5+t));
+    return box(p,vec3(cos(p.z)*.5,sin(p.z+p.x)*.5,.0),vec3(.02,0.02,3.5+t));
 }
+
 float ribbon2(vec3 p)
 {
-	return box(p,vec3(cos(p.z+1.5+p.x)*.6,sin(p.z+1.)*.3,.0),vec3(.02,0.02,3.+t));
+    return box(p,vec3(cos(p.z+1.5+p.x)*.6,sin(p.z+1.)*.3,.0),vec3(.02,0.02,3.+t));
 }
+
 float ribbon3(vec3 p)
 {
-	return box(p,vec3(sin(p.z+p.y)*.4,cos(p.z+p.x)*.5,.0),vec3(.02,0.02,4.+t));
+    return box(p,vec3(sin(p.z+p.y)*.4,cos(p.z+p.x)*.5,.0),vec3(.02,0.02,4.+t));
 }
+
 float ribbon4(vec3 p)
 {
-	return box(p,vec3(sin(p.z+1.5+p.x)*.5,cos(p.z+1.5)*.6,.0),vec3(.02,0.02,2.+t));
+    return box(p,vec3(sin(p.z+1.5+p.x)*.5,cos(p.z+1.5)*.6,.0),vec3(.02,0.02,2.+t));
 }
+
 float scene(vec3 p)
 {
-	float d = .5-abs(p.y);
-	d = min(d, ribbon1(p) );
-	d = min(d, ribbon2(p) );
-	d = min(d, ribbon3(p) );
-	d = min(d, ribbon4(p) );
-	
-	return d;
+    float d = .5-abs(p.y);
+    d = min(d, ribbon1(p) );
+    d = min(d, ribbon2(p) );
+    d = min(d, ribbon3(p) );
+    d = min(d, ribbon4(p) );
+
+    return d;
 }
 
 //-----------------------------------------------------------------------------
@@ -74,39 +77,40 @@ float scene(vec3 p)
 //Raymarche by distance field
 vec3 Raymarche(vec3 org, vec3 dir, int step)
 {
-	float d=0.0;
-	vec3 p=org;
-	
-	for(int i=0; i<64; i++)
-	{
-		d = scene(p);
-		p += d * dir;
-	}
-	
-	return p;
+    float d=0.0;
+    vec3 p=org;
+
+    for(int i=0; i<64; i++)
+    {
+        d = scene(p);
+        p += d * dir;
+    }
+
+    return p;
 }
+
 //get Normal
 vec3 getN(vec3 p)
 {
-	vec3 eps = vec3(0.01,0.0,0.0);
-	return normalize(vec3(
-		scene(p+eps.xyy)-scene(p-eps.xyy),
-		scene(p+eps.yxy)-scene(p-eps.yxy),
-		scene(p+eps.yyx)-scene(p-eps.yyx)
-	));
+    vec3 eps = vec3(0.01,0.0,0.0);
+    return normalize(vec3(
+        scene(p+eps.xyy)-scene(p-eps.xyy),
+        scene(p+eps.yxy)-scene(p-eps.yxy),
+        scene(p+eps.yyx)-scene(p-eps.yyx)
+    ));
 }
 
-//Ambiant Occlusion
+//Ambient Occlusion
 float AO(vec3 p, vec3 n)
 {
-	float dlt = 0.1;
-	float oc = 0.0, d = 1.0;
-	for(int i = 0; i<6; i++)
-	{
-		oc += (float(i) * dlt - scene(p + n * float(i) * dlt)) / d;
-		d *= 2.0;
-	}
-	return clamp(1.0 - oc, 0.0, 1.0);
+    float dlt = 0.1;
+    float oc = 0.0, d = 1.0;
+    for(int i = 0; i<6; i++)
+    {
+        oc += (float(i) * dlt - scene(p + n * float(i) * dlt)) / d;
+        d *= 2.0;
+    }
+    return clamp(1.0 - oc, 0.0, 1.0);
 }
 
 //-----------------------------------------------------------------------------
@@ -114,30 +118,26 @@ float AO(vec3 p, vec3 n)
 //-----------------------------------------------------------------------------
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	vec4 color = vec4(0.0);
-	float bass = texture2D( iChannel0, vec2(20./256.,0.25) ).x*.75+texture2D( iChannel0, vec2(50./256.,0.25) ).x*.25;
-	vec2 v = -1.0 + 2.0 * fragCoord.xy / iResolution.xy;
-	v.x *= iResolution.x/iResolution.y;
-	
-	vec3 org = vec3(texture2D( iChannel0, vec2(1./256.,0.25) ).x*.2+1.,+0.3+bass*.05,t+5.);
-	vec3 dir = normalize(vec3(v.x,-v.y,2.));
-	dir = rotateX(dir,.15);
-	dir = rotateY(dir,2.8);
-	
-	
-	vec3 p = Raymarche(org,dir,48);
-	vec3 n = getN(p);
-	
-	
-    color = vec4( max( dot(n.xy*-1.,normalize(p.xy-vec2(.0,-.1))),.0)*.01 );
-	color += vec4(1.0,0.3,0.0,1.0)/(ribbon1(p-n*.01)*20.+.75)*pow(bass,2.)*3.;
-	color += vec4(0.5,0.3,0.7,1.0)/(ribbon2(p-n*.01)*20.+.75)*pow(texture2D( iChannel0, vec2(64./256.,0.25) ).x,2.)*2.;
-	color += vec4(0.0,0.5,1.0,1.0)/(ribbon3(p-n*.01)*20.+.75)*pow(texture2D( iChannel0, vec2(128./256.,0.25) ).x,2.)*5.;
-	color += vec4(0.0,1.0,0.2,1.0)/(ribbon4(p-n*.01)*20.+.75)*pow(texture2D( iChannel0, vec2(200./256.,0.25) ).x,2.)*5.;
-	color *= AO(p,n);
-	color = mix(color,vec4(0.),vec4((min(distance(org,p)*.05,1.0))));
-	
-	
-	fragColor = color;
+    vec4 color = vec4(0.0);
+    float bass = texture2D( iChannel0, vec2(20./256.,0.25) ).x*.75+texture2D( iChannel0, vec2(50./256.,0.25) ).x*.25;
+    vec2 v = -1.0 + 2.0 * fragCoord.xy / iResolution.xy;
+    v.x *= iResolution.x/iResolution.y;
+    
+    vec3 org = vec3(texture2D( iChannel0, vec2(1./256.,0.25) ).x*.2+1.,+0.3+bass*.05,t+5.);
+    vec3 dir = normalize(vec3(v.x,-v.y,2.));
+    dir = rotateX(dir,.15);
+    dir = rotateY(dir,2.8);
 
+    vec3 p = Raymarche(org,dir,48);
+    vec3 n = getN(p);
+
+    color = vec4( max( dot(n.xy*-1.,normalize(p.xy-vec2(.0,-.1))),.0)*.01 );
+    color += vec4(1.0,0.3,0.0,1.0)/(ribbon1(p-n*.01)*20.+.75)*pow(bass,2.)*3.;
+    color += vec4(0.5,0.3,0.7,1.0)/(ribbon2(p-n*.01)*20.+.75)*pow(texture2D( iChannel0, vec2(64./256.,0.25) ).x,2.)*2.;
+    color += vec4(0.0,0.5,1.0,1.0)/(ribbon3(p-n*.01)*20.+.75)*pow(texture2D( iChannel0, vec2(128./256.,0.25) ).x,2.)*5.;
+    color += vec4(0.0,1.0,0.2,1.0)/(ribbon4(p-n*.01)*20.+.75)*pow(texture2D( iChannel0, vec2(200./256.,0.25) ).x,2.)*5.;
+    color *= AO(p,n);
+    color = mix(color,vec4(0.),vec4((min(distance(org,p)*.05,1.0))));
+
+    fragColor = color;
 }

--- a/visualization.shadertoy/resources/simplicitygalaxy.frag.glsl
+++ b/visualization.shadertoy/resources/simplicitygalaxy.frag.glsl
@@ -6,82 +6,80 @@
 
 // http://www.fractalforums.com/new-theories-and-research/very-simple-formula-for-fractal-patterns/
 float field(in vec3 p,float s) {
-	float strength = 7. + .03 * log(1.e-6 + fract(sin(iGlobalTime) * 4373.11));
-	float accum = s/4.;
-	float prev = 0.;
-	float tw = 0.;
-	for (int i = 0; i < 26; ++i) {
-		float mag = dot(p, p);
-		p = abs(p) / mag + vec3(-.5, -.4, -1.5);
-		float w = exp(-float(i) / 7.);
-		accum += w * exp(-strength * pow(abs(mag - prev), 2.2));
-		tw += w;
-		prev = mag;
-	}
-	return max(0., 5. * accum / tw - .7);
+    float strength = 7. + .03 * log(1.e-6 + fract(sin(iGlobalTime) * 4373.11));
+    float accum = s/4.;
+    float prev = 0.;
+    float tw = 0.;
+    for (int i = 0; i < 26; ++i) {
+        float mag = dot(p, p);
+        p = abs(p) / mag + vec3(-.5, -.4, -1.5);
+        float w = exp(-float(i) / 7.);
+        accum += w * exp(-strength * pow(abs(mag - prev), 2.2));
+        tw += w;
+        prev = mag;
+    }
+    return max(0., 5. * accum / tw - .7);
 }
 
 // Less iterations for second layer
 float field2(in vec3 p, float s) {
-	float strength = 7. + .03 * log(1.e-6 + fract(sin(iGlobalTime) * 4373.11));
-	float accum = s/4.;
-	float prev = 0.;
-	float tw = 0.;
-	for (int i = 0; i < 18; ++i) {
-		float mag = dot(p, p);
-		p = abs(p) / mag + vec3(-.5, -.4, -1.5);
-		float w = exp(-float(i) / 7.);
-		accum += w * exp(-strength * pow(abs(mag - prev), 2.2));
-		tw += w;
-		prev = mag;
-	}
-	return max(0., 5. * accum / tw - .7);
+    float strength = 7. + .03 * log(1.e-6 + fract(sin(iGlobalTime) * 4373.11));
+    float accum = s/4.;
+    float prev = 0.;
+    float tw = 0.;
+    for (int i = 0; i < 18; ++i) {
+        float mag = dot(p, p);
+        p = abs(p) / mag + vec3(-.5, -.4, -1.5);
+        float w = exp(-float(i) / 7.);
+        accum += w * exp(-strength * pow(abs(mag - prev), 2.2));
+        tw += w;
+        prev = mag;
+    }
+    return max(0., 5. * accum / tw - .7);
 }
 
 vec3 nrand3( vec2 co )
 {
-	vec3 a = fract( cos( co.x*8.3e-3 + co.y )*vec3(1.3e5, 4.7e5, 2.9e5) );
-	vec3 b = fract( sin( co.x*0.3e-3 + co.y )*vec3(8.1e5, 1.0e5, 0.1e5) );
-	vec3 c = mix(a, b, 0.5);
-	return c;
+    vec3 a = fract( cos( co.x*8.3e-3 + co.y )*vec3(1.3e5, 4.7e5, 2.9e5) );
+    vec3 b = fract( sin( co.x*0.3e-3 + co.y )*vec3(8.1e5, 1.0e5, 0.1e5) );
+    vec3 c = mix(a, b, 0.5);
+    return c;
 }
-
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
     vec2 uv = 2. * fragCoord.xy / iResolution.xy - 1.;
-	vec2 uvs = uv * iResolution.xy / max(iResolution.x, iResolution.y);
-	vec3 p = vec3(uvs / 4., 0) + vec3(1., -1.3, 0.);
-	p += .2 * vec3(sin(iGlobalTime / 16.), sin(iGlobalTime / 12.),  sin(iGlobalTime / 128.));
-	
-	float freqs[4];
-	//Sound
-	freqs[0] = texture2D( iChannel0, vec2( 0.01, 0.25 ) ).x;
-	freqs[1] = texture2D( iChannel0, vec2( 0.07, 0.25 ) ).x;
-	freqs[2] = texture2D( iChannel0, vec2( 0.15, 0.25 ) ).x;
-	freqs[3] = texture2D( iChannel0, vec2( 0.30, 0.25 ) ).x;
+    vec2 uvs = uv * iResolution.xy / max(iResolution.x, iResolution.y);
+    vec3 p = vec3(uvs / 4., 0) + vec3(1., -1.3, 0.);
+    p += .2 * vec3(sin(iGlobalTime / 16.), sin(iGlobalTime / 12.),  sin(iGlobalTime / 128.));
 
-	float t = field(p,freqs[2]);
-	float v = (1. - exp((abs(uv.x) - 1.) * 6.)) * (1. - exp((abs(uv.y) - 1.) * 6.));
-	
+    float freqs[4];
+    //Sound
+    freqs[0] = texture2D( iChannel0, vec2( 0.01, 0.25 ) ).x;
+    freqs[1] = texture2D( iChannel0, vec2( 0.07, 0.25 ) ).x;
+    freqs[2] = texture2D( iChannel0, vec2( 0.15, 0.25 ) ).x;
+    freqs[3] = texture2D( iChannel0, vec2( 0.30, 0.25 ) ).x;
+
+    float t = field(p,freqs[2]);
+    float v = (1. - exp((abs(uv.x) - 1.) * 6.)) * (1. - exp((abs(uv.y) - 1.) * 6.));
+
     //Second Layer
-	vec3 p2 = vec3(uvs / (4.+sin(iGlobalTime*0.11)*0.2+0.2+sin(iGlobalTime*0.15)*0.3+0.4), 1.5) + vec3(2., -1.3, -1.);
-	p2 += 0.25 * vec3(sin(iGlobalTime / 16.), sin(iGlobalTime / 12.),  sin(iGlobalTime / 128.));
-	float t2 = field2(p2,freqs[3]);
-	vec4 c2 = mix(.4, 1., v) * vec4(1.3 * t2 * t2 * t2 ,1.8  * t2 * t2 , t2* freqs[0], t2);
-	
-	
-	//Let's add some stars
-	//Thanks to http://glsl.heroku.com/e#6904.0
-	vec2 seed = p.xy * 2.0;	
-	seed = floor(seed * iResolution.x);
-	vec3 rnd = nrand3( seed );
-	vec4 starcolor = vec4(pow(rnd.y,40.0));
-	
-	//Second Layer
-	vec2 seed2 = p2.xy * 2.0;
-	seed2 = floor(seed2 * iResolution.x);
-	vec3 rnd2 = nrand3( seed2 );
-	starcolor += vec4(pow(rnd2.y,40.0));
-	
-	fragColor = mix(freqs[3]-.3, 1., v) * vec4(1.5*freqs[2] * t * t* t , 1.2*freqs[1] * t * t, freqs[3]*t, 1.0)+c2+starcolor;
+    vec3 p2 = vec3(uvs / (4.+sin(iGlobalTime*0.11)*0.2+0.2+sin(iGlobalTime*0.15)*0.3+0.4), 1.5) + vec3(2., -1.3, -1.);
+    p2 += 0.25 * vec3(sin(iGlobalTime / 16.), sin(iGlobalTime / 12.),  sin(iGlobalTime / 128.));
+    float t2 = field2(p2,freqs[3]);
+    vec4 c2 = mix(.4, 1., v) * vec4(1.3 * t2 * t2 * t2 ,1.8  * t2 * t2 , t2* freqs[0], t2);
+
+    //Let's add some stars
+    //Thanks to http://glsl.heroku.com/e#6904.0
+    vec2 seed = p.xy * 2.0;    
+    seed = floor(seed * iResolution.x);
+    vec3 rnd = nrand3( seed );
+    vec4 starcolor = vec4(pow(rnd.y,40.0));
+
+    //Second Layer
+    vec2 seed2 = p2.xy * 2.0;
+    seed2 = floor(seed2 * iResolution.x);
+    vec3 rnd2 = nrand3( seed2 );
+    starcolor += vec4(pow(rnd2.y,40.0));
+
+    fragColor = mix(freqs[3]-.3, 1., v) * vec4(1.5*freqs[2] * t * t* t , 1.2*freqs[1] * t * t, freqs[3]*t, 1.0)+c2+starcolor;
 }

--- a/visualization.shadertoy/resources/soundflower.frag.glsl
+++ b/visualization.shadertoy/resources/soundflower.frag.glsl
@@ -5,19 +5,19 @@
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	vec2 uv = -1.0+2.0*fragCoord.xy/iResolution.xy;
-	uv.x *= iResolution.x/iResolution.y;
-	
-	float r = length( uv );
-	float a = atan( uv.x, uv.y );
+    vec2 uv = -1.0+2.0*fragCoord.xy/iResolution.xy;
+    uv.x *= iResolution.x/iResolution.y;
 
-	float w = texture2D( iChannel0, vec2( abs(a)/6.28,1.0) ).x;
-	
-	float t = 3.0*sqrt(abs(w-0.5));
+    float r = length( uv );
+    float a = atan( uv.x, uv.y );
 
-	float f = 0.0;
-	if( r<t ) f = (1.0-r/t);
-	vec3 col = pow( vec3(f), vec3(1.5,1.1,0.8) );
+    float w = texture2D( iChannel0, vec2( abs(a)/6.28,1.0) ).x;
 
-	fragColor = vec4( col, 1.0 );
+    float t = 3.0*sqrt(abs(w-0.5));
+
+    float f = 0.0;
+    if( r<t ) f = (1.0-r/t);
+    vec3 col = pow( vec3(f), vec3(1.5,1.1,0.8) );
+
+    fragColor = vec4( col, 1.0 );
 }

--- a/visualization.shadertoy/resources/soundsinuswave.frag.glsl
+++ b/visualization.shadertoy/resources/soundsinuswave.frag.glsl
@@ -3,22 +3,22 @@
 #define WAVES 8.0
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
-	vec2 uv = -1.0 + 2.0 * fragCoord.xy / iResolution.xy;
+    vec2 uv = -1.0 + 2.0 * fragCoord.xy / iResolution.xy;
 
-	float time = iGlobalTime * 1.0;
-	
-	vec3 color = vec3(0.0);
+    float time = iGlobalTime * 1.0;
 
-	for (float i=0.0; i<WAVES + 1.0; i++) {
-		float freq = texture2D(iChannel0, vec2(i / WAVES, 0.0)).x * 7.0;
+    vec3 color = vec3(0.0);
 
-		vec2 p = vec2(uv);
+    for (float i=0.0; i<WAVES + 1.0; i++) {
+        float freq = texture2D(iChannel0, vec2(i / WAVES, 0.0)).x * 7.0;
 
-		p.x += i * 0.04 + freq * 0.03;
-		p.y += sin(p.x * 10.0 + time) * cos(p.x * 2.0) * freq * 0.2 * ((i + 1.0) / WAVES);
-		float intensity = abs(0.01 / p.y) * clamp(freq, 0.35, 2.0);
-		color += vec3(1.0 * intensity * (i / 5.0), 0.5 * intensity, 1.75 * intensity) * (3.0 / WAVES);
-	}
+        vec2 p = vec2(uv);
 
-	fragColor = vec4(color, 1.0);
+        p.x += i * 0.04 + freq * 0.03;
+        p.y += sin(p.x * 10.0 + time) * cos(p.x * 2.0) * freq * 0.2 * ((i + 1.0) / WAVES);
+        float intensity = abs(0.01 / p.y) * clamp(freq, 0.35, 2.0);
+        color += vec3(1.0 * intensity * (i / 5.0), 0.5 * intensity, 1.75 * intensity) * (3.0 / WAVES);
+    }
+
+    fragColor = vec4(color, 1.0);
 }

--- a/visualization.shadertoy/resources/symmetricalsound.frag.glsl
+++ b/visualization.shadertoy/resources/symmetricalsound.frag.glsl
@@ -2,30 +2,29 @@
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	vec2 uv = fragCoord.xy / iResolution.xy;
-	if(uv.x > 0.5)
-	{
-		uv -= 0.5;
-		uv *= 2.;
-	}
-	else
-	{
-		uv *= 2.;
-		uv = 1. - uv;
-	}
+    vec2 uv = fragCoord.xy / iResolution.xy;
+    if(uv.x > 0.5)
+    {
+        uv -= 0.5;
+        uv *= 2.;
+    }
+    else
+    {
+        uv *= 2.;
+        uv = 1. - uv;
+    }
 
-	float fft  = texture2D( iChannel0, vec2(uv.x,0.25) ).x; 
-	float dr = length(uv);
-	float radius = 1.8;
-	
-	vec3 col = vec3(0.);
-	if( abs(uv.y)<fft )
-	{
-		col = mix( vec3(0.), vec3( fft, fft*(1.0-fft), 1.0-fft ) * fft * fft, fft);
-	}
+    float fft  = texture2D( iChannel0, vec2(uv.x,0.25) ).x; 
+    float dr = length(uv);
+    float radius = 1.8;
 
+    vec3 col = vec3(0.);
+    if( abs(uv.y)<fft )
+    {
+        col = mix( vec3(0.), vec3( fft, fft*(1.0-fft), 1.0-fft ) * fft * fft, fft);
+    }
 
-	fragColor.x = 0.5 - smoothstep(dr, 0.0, radius * col.x);
-	fragColor.y = 1.5 - smoothstep(dr, 0.0, radius * col.z);
-	fragColor.z = 1.5 - smoothstep(dr, 0.0, radius * col.x);
+    fragColor.x = 0.5 - smoothstep(dr, 0.0, radius * col.x);
+    fragColor.y = 1.5 - smoothstep(dr, 0.0, radius * col.z);
+    fragColor.z = 1.5 - smoothstep(dr, 0.0, radius * col.x);
 }

--- a/visualization.shadertoy/resources/twistedrings.frag.glsl
+++ b/visualization.shadertoy/resources/twistedrings.frag.glsl
@@ -7,18 +7,18 @@
 
 float drawCircle(float r, float polarRadius, float thickness)
 {
-	return 	smoothstep(r, r + thickness, polarRadius) - 
-        	smoothstep(r + thickness, r + 2.0 * thickness, polarRadius);
+    return smoothstep(r, r + thickness, polarRadius) - 
+           smoothstep(r + thickness, r + 2.0 * thickness, polarRadius);
 }
 
 float sin01(float v)
 {
-	return 0.5 + 0.5 * sin(v);
+    return 0.5 + 0.5 * sin(v);
 }
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	vec2 uv = fragCoord.xy / iResolution.xy;
+    vec2 uv = fragCoord.xy / iResolution.xy;
     
     float rstandard = SOUND_MULTIPLIER * texture2D( iChannel0, vec2(0.1, 0.0) ).x;
     
@@ -29,32 +29,32 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
     // Calculate polar coordinates
     float pr = length(p);
     float pa = atan(p.y, p.x); // * 3.0 / 3.14;
-    
+
     // Retrieve the information from the texture
     float idx = (pa/3.1415 + 1.0) / 2.0;   // 0 to 1
     float idx2 = idx * 3.1415;             // 0 to PI
-    
+
     // Get the data from the microphone
     vec2 react = sin(idx2) * SOUND_MULTIPLIER * texture2D( iChannel0, vec2(idx, 0.0) ).xy;    
-    
+
     // Draw the circles
     float o = 0.0;
     float inc = 0.0;
-    
+
     for( float i = 1.0 ; i < 8.0 ; i += 1.0 )
     {
         float baseradius = 0.3 * ( 0.3 + sin01(rstandard + iGlobalTime * 0.2) ); 
         float radius = baseradius + inc;
 
         radius += 0.01 * ( sin01(pa * i + iGlobalTime * (i - 1.0) ) );
-        
-    	o += drawCircle(radius, pr, 0.008 * (1.0 + react.x * (i - 1.0)));
-        
+
+        o += drawCircle(radius, pr, 0.008 * (1.0 + react.x * (i - 1.0)));
+
         inc += 0.005;
     }
-    
+
     // Calculate the background color    
     vec3 bcol = vec3(1.0, 0.22, 0.5 - 0.4*p.y) * (1.0 - 0.6 * pr * react.x);
     vec3 col = mix(bcol, vec3(1.0,1.0,0.7), o);
-	fragColor = vec4(col, 1.0);
+    fragColor = vec4(col, 1.0);
 }

--- a/visualization.shadertoy/resources/undulantspectre.frag.glsl
+++ b/visualization.shadertoy/resources/undulantspectre.frag.glsl
@@ -6,40 +6,39 @@ float BLOCK_WIDTH = 0.01;
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-	vec2 uv = fragCoord.xy / iResolution.xy;
-	
-	vec3 final_color = vec3(1.0);
-	vec3 bg_color = vec3(0.0);
-	vec3 wave_color = vec3(0.0);
-	
-	bg_color = mix(COLOR1, COLOR2, uv.x) + texture2D(iChannel0, vec2(uv.x/8., abs(.5 - uv.y))).rgb - .7;
-	
-	float wave_width;
-	uv  = -1.0 + 2.0 * uv;
-	uv.y += 0.1;
-	uv.x *= 2.;
-	const float n = 20.;
-	float prev = 0.;
-	float curr = .6;
-	float next = texture2D(iChannel0, vec2(0.,0.)).r;
-	
-	for(float i = 0.0; i < n; i++) {
-		prev = curr;
-		curr = next;
-		next = texture2D(iChannel0, vec2((i+1.)/n,0.)).r;
-		
-		float a = max(0., curr * 2. - prev - next);
-		
-		uv.y += (1. * cos(mod(uv.x * 2. * i / n * 10. + iGlobalTime * i, 2.*3.14)) * a * a);
-		uv.x += 0.1;
-		
-		wave_width = abs(1.0 / (200.0 * uv.y));
-		
-		wave_color += vec3(wave_width * 1.9, wave_width, wave_width * 1.5) * 5. / n;
-	}
-	
-	final_color = bg_color + wave_color;
-	
-	
-	fragColor = vec4(final_color, 1.0);
+    vec2 uv = fragCoord.xy / iResolution.xy;
+
+    vec3 final_color = vec3(1.0);
+    vec3 bg_color = vec3(0.0);
+    vec3 wave_color = vec3(0.0);
+
+    bg_color = mix(COLOR1, COLOR2, uv.x) + texture2D(iChannel0, vec2(uv.x/8., abs(.5 - uv.y))).rgb - .7;
+
+    float wave_width;
+    uv  = -1.0 + 2.0 * uv;
+    uv.y += 0.1;
+    uv.x *= 2.;
+    const float n = 20.;
+    float prev = 0.;
+    float curr = .6;
+    float next = texture2D(iChannel0, vec2(0.,0.)).r;
+
+    for(float i = 0.0; i < n; i++) {
+        prev = curr;
+        curr = next;
+        next = texture2D(iChannel0, vec2((i+1.)/n,0.)).r;
+
+        float a = max(0., curr * 2. - prev - next);
+
+        uv.y += (1. * cos(mod(uv.x * 2. * i / n * 10. + iGlobalTime * i, 2.*3.14)) * a * a);
+        uv.x += 0.1;
+
+        wave_width = abs(1.0 / (200.0 * uv.y));
+
+        wave_color += vec3(wave_width * 1.9, wave_width, wave_width * 1.5) * 5. / n;
+    }
+
+    final_color = bg_color + wave_color;
+
+    fragColor = vec4(final_color, 1.0);
 }

--- a/visualization.shadertoy/resources/wavesremix.frag.glsl
+++ b/visualization.shadertoy/resources/wavesremix.frag.glsl
@@ -9,24 +9,24 @@ float getWeight(float f) {
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {    
-	vec2 uvTrue = fragCoord.xy / iResolution.xy;
+    vec2 uvTrue = fragCoord.xy / iResolution.xy;
     vec2 uv = -1.0 + 2.0 * uvTrue;
-    
-	float lineIntensity;
+
+    float lineIntensity;
     float glowWidth;
     vec3 color = vec3(0.0);
-    
-	for(float i = 0.0; i < 5.0; i++) {
-        
-		uv.y += (0.2 * sin(uv.x + i/7.0 - iGlobalTime * 0.6));
+
+    for(float i = 0.0; i < 5.0; i++) {
+
+        uv.y += (0.2 * sin(uv.x + i/7.0 - iGlobalTime * 0.6));
         float Y = uv.y + getWeight(squared(i) * 20.0) *
             (texture2D(iChannel0, vec2(uvTrue.x, 1)).x - 0.5);
         lineIntensity = 0.4 + squared(1.6 * abs(mod(uvTrue.x + i / 1.3 + iGlobalTime,2.0) - 1.0));
-		glowWidth = abs(lineIntensity / (150.0 * Y));
-		color += vec3(glowWidth * (2.0 + sin(iGlobalTime * 0.13)),
+        glowWidth = abs(lineIntensity / (150.0 * Y));
+        color += vec3(glowWidth * (2.0 + sin(iGlobalTime * 0.13)),
                       glowWidth * (2.0 - sin(iGlobalTime * 0.23)),
                       glowWidth * (2.0 - cos(iGlobalTime * 0.19)));
-	}	
-	
-	fragColor = vec4(color, 1.0);
+    }    
+
+    fragColor = vec4(color, 1.0);
 }


### PR DESCRIPTION
Best reviewed with ?w=1

https://github.com/uNiversaI/visualization.shadertoy/commit/a3c38385dfcaa7b0d35f739b19413aaa0625ef6d?w=1

Essentially all shaders code, all tabs are now spaces and removed empty lines and adjusted indenting

Things just were all over the place while I was trying to find reason why a couple of visualizations cause kodi to restart.

Couldn't find the reason it but once I did one had to do them all.

Some more cleanup could have happened.
A Few of these visualisations have commented out code which isn't in use and that can be removed safely but I left it in it may facilitate some modifications in future.
